### PR TITLE
chore: add scoped agent instructions

### DIFF
--- a/fitness-app/.github/AGENTS.md
+++ b/fitness-app/.github/AGENTS.md
@@ -1,0 +1,108 @@
+# GitHub and CI/CD Instructions
+
+These instructions extend the repository-level `AGENTS.md` for `.github/`.
+
+## Ownership
+
+Primary owner: `devops_engineer`.
+
+Use `project_manager` for issue/PR workflow conventions, `tech_lead` for required architectural gates, `qa_engineer` for test-gate strategy, and `security_engineer` for workflow permissions, secret exposure, dependency security, or release-signing concerns.
+
+## Pull request policy
+
+- All production changes go through Pull Requests.
+- Never commit directly to `main`.
+- Keep PRs focused on one bounded change whenever practical.
+- Link the relevant Issue when one exists.
+- PR descriptions should state: goal, scope, notable implementation choices, test evidence, risks, and follow-up work.
+- Do not merge solely because an implementation agent reports success.
+
+## CI principles
+
+CI must progressively enforce the repository Definition of Done. Relevant checks should include, as the codebase becomes available:
+- backend formatting/lint
+- backend type checking
+- backend tests
+- migration validation
+- mobile formatting/lint
+- mobile type checking
+- mobile tests
+- build/configuration validation
+
+Do not add placeholder green checks that provide no real validation.
+
+## Workflow design
+
+- Give workflows explicit, readable names.
+- Use least-privilege `permissions` declarations.
+- Avoid `write-all`.
+- Pin third-party actions to stable versions according to the repository dependency/security policy.
+- Avoid executing untrusted PR code with privileged secrets.
+- Be cautious with `pull_request_target`; use it only with an explicit security rationale.
+- Cache dependencies only when cache keys cannot cause unsafe cross-context behavior.
+- Keep CI deterministic and independent of developer-machine state.
+
+## Secrets
+
+- Never embed secrets in workflow YAML.
+- Reference repository/environment secrets only where required.
+- Prefer environment-scoped production secrets.
+- Do not expose privileged secrets to fork/untrusted code paths.
+- Do not print secrets or sensitive environment values to logs.
+
+## Branch protection target
+
+`main` should ultimately require Pull Requests and required CI status checks before merge. Until those checks exist, do not invent required status names that are not backed by workflows.
+
+As M0 progresses, coordinate branch-protection rules with the actual workflow job/check names so the branch cannot be permanently blocked by nonexistent checks.
+
+## CODEOWNERS
+
+When `CODEOWNERS` is introduced, keep ownership aligned with the repository operating model:
+- `apps/mobile/` -> mobile ownership plus technical review
+- `services/api/` -> backend ownership plus technical review
+- `database/` -> data ownership plus technical review
+- `infra/` and `.github/` -> DevOps ownership plus technical review
+- `docs/architecture/` -> Tech Lead ownership
+
+Do not invent GitHub usernames or teams. Add concrete owners only after valid repository collaborators/teams are known.
+
+## Issue templates
+
+Issue templates should capture enough information for safe agent execution:
+- context
+- goal
+- scope
+- out of scope
+- dependencies
+- affected modules
+- acceptance criteria
+- required tests
+- risk/notes
+
+Avoid templates that encourage broad multi-feature Issues.
+
+## PR templates
+
+PR templates should prompt for:
+- linked Issue
+- summary
+- scope
+- test evidence
+- database/migration impact
+- API contract impact
+- security/privacy impact
+- screenshots or UX evidence when relevant
+- checklist against Definition of Done
+
+## Before completing work
+
+- validate YAML/configuration syntax
+- inspect workflow triggers and permissions
+- verify no secrets are embedded
+- verify referenced commands/files actually exist when the workflow is expected to run
+- avoid creating required checks before their workflows exist
+- verify acceptance criteria
+- report anything that could not be validated
+
+Do not weaken CI, review requirements, or security controls merely to make a failing pipeline green.

--- a/fitness-app/apps/mobile/AGENTS.md
+++ b/fitness-app/apps/mobile/AGENTS.md
@@ -1,0 +1,82 @@
+# Mobile Engineering Instructions
+
+These instructions extend the repository-level `AGENTS.md` for `apps/mobile/`.
+
+## Ownership
+
+Primary implementation owner: `mobile_engineer`.
+
+Use `qa_engineer` for independent test design and regression verification. Use `tech_lead` when a change alters navigation architecture, state boundaries, offline synchronization semantics, API contracts, or introduces a major dependency. Use `security_engineer` for authentication, local sensitive-data storage, media permissions, privacy, or credential-related changes.
+
+## Technology baseline
+
+The mobile application uses:
+- React Native
+- Expo
+- TypeScript
+- Expo Router
+- TanStack Query for server state
+- Zustand for bounded client state
+- React Hook Form + Zod for forms and validation
+- Expo SQLite for local persistence and offline workflows
+
+Do not replace these technologies or add overlapping state, routing, form, or persistence frameworks without an approved architectural decision.
+
+## Design rules
+
+- Keep TypeScript strict and avoid `any` unless a concrete boundary requires it and the reason is documented.
+- Prefer feature-oriented code with small reusable UI components.
+- Keep route files thin; domain/UI logic belongs in feature modules, hooks, services, or components.
+- Treat TanStack Query as the primary cache for remote/server state.
+- Use Zustand only for state that is genuinely client-local or cross-screen and cannot be represented cleanly by route state, component state, SQLite, or TanStack Query.
+- Do not duplicate server data into multiple client stores without a documented reason.
+- Validate user input at the form boundary with shared or explicit schemas.
+- Accessibility is required: labels, touch targets, semantic roles, keyboard behavior, and readable error states must be considered.
+
+## API integration
+
+- Do not invent backend contracts.
+- Do not manually edit generated API-client files.
+- If the required endpoint or field is absent, report the exact contract required and coordinate with `backend_engineer` / `tech_lead`.
+- Never trust client-side checks as authorization.
+- Never hard-code production endpoints, tokens, service-role keys, or secrets.
+- Handle network failures explicitly; do not silently discard user actions.
+
+## Offline-first workout behavior
+
+Workout recording must remain usable when the network is unavailable.
+
+- Persist user workout actions locally according to the approved synchronization design.
+- Surface meaningful synchronization state when pending or failed writes affect the user.
+- Do not invent conflict-resolution or idempotency rules; follow the relevant ADR/design document.
+- A successful local UI update must not falsely imply that remote synchronization has succeeded.
+- Preserve enough local information to retry recoverable synchronization failures.
+
+## UI and UX
+
+- Optimize the workout-entry flow for low interaction cost in a gym context.
+- Avoid blocking UI on network calls when the workflow is designed to operate locally.
+- Loading, empty, error, offline, and retry states are part of the feature, not optional polish.
+- Platform-specific code should be isolated behind small interfaces when possible.
+
+## Testing
+
+For each functional change, add the smallest useful combination of:
+- unit tests for pure logic
+- component tests for UI behavior
+- integration tests for feature flows
+- synchronization/offline tests when persistence or networking changes
+
+Avoid brittle tests tied to incidental implementation details. Do not weaken assertions merely to make CI pass.
+
+## Before completing work
+
+- inspect the complete diff
+- run the configured TypeScript checks
+- run the configured lint/format checks
+- run relevant mobile tests
+- verify offline/error states where applicable
+- verify acceptance criteria
+- report anything that could not be validated
+
+Do not modify backend, database migrations, infrastructure, or unrelated application areas as part of a mobile task.

--- a/fitness-app/database/AGENTS.md
+++ b/fitness-app/database/AGENTS.md
@@ -1,0 +1,106 @@
+# Database and Analytics Engineering Instructions
+
+These instructions extend the repository-level `AGENTS.md` for `database/`.
+
+## Ownership
+
+Primary owner: `data_engineer`.
+
+Structural schema changes, Alembic migrations, data constraints, indexes, seed strategy, ranking SQL, and historical-data integrity belong to this role. Use `tech_lead` for material modelling decisions, `qa_engineer` for migration/integration validation, and `security_engineer` when RLS, privacy, ownership, or sensitive-data access is involved.
+
+## Database principles
+
+- PostgreSQL is the persistent system of record.
+- Prefer normalized relational structures for core domain data.
+- Raw workout records are authoritative source data.
+- Derived statistics and rankings must be reproducible from source workout data.
+- Use database constraints to enforce invariants that must never be violated.
+- Foreign keys must be explicit unless a documented reason prevents them.
+- Nullability must be intentional.
+- Naming must remain consistent across schema, ORM and API design.
+- Do not store opaque JSON for relational domain concepts merely to avoid proper modelling.
+
+## Identifiers and timestamps
+
+Follow the repository-wide conventions documented by architecture decisions. Do not introduce a new identifier strategy, timestamp timezone convention, or soft-delete pattern within an isolated migration.
+
+## Migrations
+
+Structural migrations are owned by `data_engineer`.
+
+For every migration:
+- make the intended schema transition explicit
+- assess data-loss risk
+- assess lock/runtime impact where relevant
+- prefer additive and backwards-compatible changes
+- consider deployment ordering between old/new application versions
+- provide deterministic upgrade behavior
+- provide downgrade behavior when reasonably safe; otherwise document why rollback requires a forward fix
+- never silently discard, truncate, or reinterpret existing production data
+
+Destructive operations require explicit authorization and a documented data-migration/backout strategy.
+
+Do not modify an existing migration that may already have been applied to a shared environment; create a new migration instead unless the repository is unequivocally still pre-deployment and the task explicitly authorizes rewriting history.
+
+## Constraints and indexes
+
+- Use unique constraints for true domain uniqueness.
+- Use check constraints for stable database-level invariants where practical.
+- Indexes require a stated query/access pattern; avoid speculative indexing.
+- Consider composite-index column order against actual filters/sorts.
+- Consider partial indexes when they materially improve a known access pattern.
+- Foreign-key columns used in common joins/deletes should be evaluated for indexes.
+
+## Exercise and workout modelling
+
+Keep distinctions explicit between:
+- canonical exercises and user-defined/custom exercises
+- exercises and their muscle relationships
+- workout sessions, workout exercises and individual sets
+- raw measurements and derived performance statistics
+
+Do not assume every exercise is represented only by weight and repetitions. The schema must be able to accommodate the approved exercise measurement types without making irrelevant fields mandatory.
+
+## Rankings and analytics
+
+- Exercise rankings and aggregate muscle scores are different metrics.
+- Do not compare raw weight values across arbitrary machines as equivalent measures of strength.
+- Estimated 1RM methodology must be explicit, versionable if methodology may evolve, and covered by tests.
+- Volume calculations must define exactly which sets count.
+- Time-window boundaries for week/month/year must be explicit and timezone-aware according to the approved product convention.
+- Ranking ties must have deterministic behavior.
+- Group rankings must enforce membership/visibility semantics through the application/security design.
+- Cached/materialized derived data must be regenerable from source data and must not become the sole source of truth.
+
+## Seed and catalog data
+
+- Keep seed operations deterministic and repeatable.
+- Distinguish development/test fixtures from product catalog seed data.
+- Imported exercise data must preserve provenance/licensing metadata when required by the product design.
+- Do not make runtime application availability depend on an external exercise API when the architecture calls for an internal curated catalog.
+
+## Testing
+
+Changes should include relevant:
+- migration upgrade tests
+- migration/data-preservation tests when existing data is transformed
+- constraint tests
+- PostgreSQL integration tests
+- analytical-query tests
+- deterministic ranking/tie tests
+- boundary-date tests for period calculations
+
+Do not validate PostgreSQL-specific behavior solely against SQLite.
+
+## Before completing work
+
+- inspect the schema and migration diff
+- run the complete migration chain on a clean database
+- test upgrade from the relevant previous revision when applicable
+- run database/integration tests
+- inspect generated SQL for material analytical queries
+- evaluate data-loss and deployment risks
+- verify acceptance criteria
+- report anything that could not be validated
+
+Do not modify mobile UI, unrelated backend features, CI/CD, or infrastructure as part of a database task.

--- a/fitness-app/infra/AGENTS.md
+++ b/fitness-app/infra/AGENTS.md
@@ -1,0 +1,86 @@
+# Infrastructure Engineering Instructions
+
+These instructions extend the repository-level `AGENTS.md` for `infra/`.
+
+## Ownership
+
+Primary owner: `devops_engineer`.
+
+Use `tech_lead` for material infrastructure architecture changes, `qa_engineer` for deployment/test-environment validation, and `security_engineer` for secrets, network exposure, privilege boundaries, storage permissions, or production access concerns.
+
+## Infrastructure principles
+
+- Prefer the simplest infrastructure that satisfies the current product requirement.
+- Preserve portability where practical; application architecture must not become unnecessarily coupled to one hosting vendor.
+- Docker is the baseline packaging mechanism for backend services.
+- Environments are separated as LOCAL, TEST, STAGING, and PRODUCTION.
+- Staging and production must use separate credentials and data stores.
+- Infrastructure configuration must be reproducible from version-controlled files plus external secrets.
+- Do not introduce Kubernetes, service meshes, message brokers, or additional managed services without a demonstrated requirement and architectural approval.
+
+## Secrets and configuration
+
+- Never commit secrets, API tokens, passwords, service-role keys, certificates, private keys, or production credentials.
+- Use environment variables or the approved secret-management facility.
+- Provide `.env.example`-style documentation with names and safe placeholder values when configuration is required.
+- Distinguish public client configuration from privileged server-only configuration.
+- Supabase privileged/service-role credentials are server-side only.
+- Default configurations should fail safely when required secrets are missing.
+
+## Docker
+
+- Keep images reproducible and minimal without sacrificing debuggability needed by the environment.
+- Use explicit build contexts and avoid copying unrelated repository content.
+- Use `.dockerignore` appropriately.
+- Run production containers as non-root when practical.
+- Define health checks where they materially improve orchestration/deployment reliability.
+- Do not bake secrets into image layers.
+- Pin/constrain base images and dependencies according to the repository dependency policy.
+
+## Local development
+
+Local setup should converge toward a documented command sequence that allows a clean checkout to start required development services consistently.
+
+- Avoid hidden manual host configuration.
+- Do not require production credentials for local development.
+- Keep local database/service initialization deterministic.
+- Preserve useful logs and error visibility.
+
+## Environments and deployment
+
+- Treat staging as the integration environment for the real mobile/API/Auth/Storage stack before production.
+- Production changes must be explicit and reviewable.
+- Destructive infrastructure operations must never occur implicitly during ordinary application deployment.
+- Database migration ordering must be coordinated with `data_engineer` and backend compatibility requirements.
+- Prefer zero/low-downtime compatible changes where reasonable.
+
+## Observability
+
+Add observability incrementally when there is an operational need. At minimum, architecture should allow:
+- structured application logs
+- error visibility
+- health/readiness checks where useful
+- deployment traceability by version/commit
+
+Do not log secrets, authentication tokens, passwords, or unnecessary personal data.
+
+## Security
+
+- Apply least privilege to deployment credentials and service accounts.
+- Expose only required network ports/services.
+- Separate public endpoints from administrative/internal capabilities.
+- Review CORS, TLS termination, storage permissions, and secret boundaries whenever relevant.
+- Security-sensitive infrastructure changes require `security_engineer` review.
+
+## Before completing work
+
+- validate configuration syntax
+- inspect the complete diff
+- verify no secrets are present
+- verify local setup remains reproducible
+- validate relevant container builds/configuration
+- explain environment/deployment impact
+- verify acceptance criteria
+- report anything that could not be validated
+
+Do not modify application business logic, database domain modelling, or mobile UI as part of an infrastructure task.

--- a/fitness-app/services/api/AGENTS.md
+++ b/fitness-app/services/api/AGENTS.md
@@ -1,0 +1,115 @@
+# Backend Engineering Instructions
+
+These instructions extend the repository-level `AGENTS.md` for `services/api/`.
+
+## Ownership
+
+Primary implementation owner: `backend_engineer`.
+
+Use `data_engineer` for structural database schema changes and migrations. Use `qa_engineer` for independent API/integration verification. Use `tech_lead` for cross-module contracts, architectural changes, or major dependencies. Use `security_engineer` for authentication, authorization, privacy, upload, secret, or sensitive-data changes.
+
+## Technology baseline
+
+The backend uses:
+- Python 3
+- FastAPI
+- Pydantic
+- SQLAlchemy 2
+- Alembic
+- PostgreSQL
+- Supabase Auth integration
+- pytest
+
+Do not replace these technologies or introduce a competing application framework without an approved architectural decision.
+
+## Module structure
+
+Use the modular-monolith pattern. Prefer feature/domain modules such as:
+- auth
+- users
+- exercises
+- workouts
+- groups
+- rankings
+- analytics
+- social
+- media
+- notifications
+
+Within a feature, keep responsibilities separated conceptually as:
+
+`router -> service -> repository -> database`
+
+- Routers handle HTTP concerns, dependency injection, request/response mapping, and status codes.
+- Services contain business rules and orchestration.
+- Repositories contain persistence access.
+- Pydantic schemas define public request/response contracts.
+- SQLAlchemy models must not leak directly as public API contracts.
+
+## Python quality
+
+- Use explicit typing for public functions and important internal boundaries.
+- Follow PEP 8 and the configured formatter/linter.
+- Prefer small functions with single responsibilities.
+- Avoid hidden global state.
+- Avoid broad exception catches unless the error is translated intentionally.
+- Do not suppress type errors without documenting why.
+
+## API contracts
+
+- Treat OpenAPI as a contract with the mobile client.
+- Preserve backwards compatibility unless the Issue explicitly allows a breaking change.
+- Use consistent naming, pagination, validation, and error semantics defined by repository architecture docs.
+- Do not add undocumented response fields as an accidental side effect of ORM serialization.
+- Return appropriate HTTP status codes; do not encode failures as successful `200` responses.
+- Mutation endpoints that participate in offline synchronization must follow the approved idempotency/conflict strategy.
+
+## Authentication and authorization
+
+- Authentication proves identity; authorization must still be enforced for every protected resource.
+- Never trust ownership, group membership, roles, visibility, or permissions supplied only by the client.
+- Resource access must be checked server-side.
+- Do not expose privileged Supabase credentials to mobile clients.
+- Sensitive authorization changes require `security_engineer` review.
+
+## Database boundary
+
+`backend_engineer` must not create or modify structural Alembic migrations unless explicitly delegated by `data_engineer`.
+
+If implementation requires a schema change:
+1. describe the required table/column/constraint/index change,
+2. coordinate with `data_engineer`,
+3. continue only against the agreed schema/contract.
+
+Do not work around missing schema by adding JSON blobs, duplicated columns, or ad-hoc persistence.
+
+## Business rules
+
+- Authoritative business rules live server-side.
+- Ranking and derived-statistic formulas must have one authoritative implementation.
+- Raw workout data remains the source of truth for reproducible analytics.
+- Avoid embedding domain logic in SQL query construction when it belongs in a named service/domain function, unless the logic is inherently set-based and documented.
+
+## Testing
+
+For changes in this subtree, add relevant:
+- unit tests for pure/domain logic
+- service tests
+- repository/database integration tests
+- FastAPI endpoint tests
+- authorization tests for protected resources
+- regression tests for fixed bugs
+
+Tests should use real PostgreSQL semantics for behavior that depends on PostgreSQL; do not assume SQLite is an equivalent integration database.
+
+## Before completing work
+
+- inspect the complete diff
+- run configured formatting/lint checks
+- run configured type checks
+- run relevant pytest suites
+- inspect OpenAPI changes when endpoints/schemas changed
+- verify acceptance criteria
+- report anything that could not be validated
+
+Do not modify mobile code, structural database migrations, infrastructure, or unrelated modules as part of a backend task.


### PR DESCRIPTION
## Summary
Adds hierarchical `AGENTS.md` instructions for the main engineering subtrees so Codex agents inherit domain-specific rules in addition to the repository-level operating model.

## Scope
- `fitness-app/apps/mobile/AGENTS.md`
- `fitness-app/services/api/AGENTS.md`
- `fitness-app/database/AGENTS.md`
- `fitness-app/infra/AGENTS.md`
- `fitness-app/.github/AGENTS.md`

## Intent
- reinforce agent ownership boundaries
- prevent mobile/backend/database contract drift
- formalize offline-first mobile constraints
- reserve structural migrations for the data engineer
- define infrastructure and CI safety rules
- avoid inventing CI check names or CODEOWNERS identities before those resources exist

## Validation
- branch is based on current `main`
- only the five scoped instruction files are added
- no production code, migrations or infrastructure behavior is changed

## Follow-up
After merge, proceed with M0 Engineering Foundation: project documentation/ADR skeleton, issue and PR templates, CI scaffolding, and branch protection once real CI checks exist.