### PR TITLE
chore: establish M0 governance and architecture docs

### DIFF
--- a/fitness-app/.github/ISSUE_TEMPLATE/bug.yml
+++ b/fitness-app/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,83 @@
+name: Bug
+
+description: Report a reproducible defect
+
+title: "[BUG] "
+
+labels: []
+
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the defect and its user or system impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Branch/version, platform, device/runtime, backend/database environment, and any relevant configuration.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, screenshots, failing tests, request/response examples, or relevant identifiers. Do not include secrets or personal data unnecessarily.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P0 - critical / data loss / security / unusable core flow
+        - P1 - major functional failure
+        - P2 - normal defect
+        - P3 - minor or cosmetic
+    validations:
+      required: true
+
+  - type: textarea
+    id: suspected_scope
+    attributes:
+      label: Suspected scope
+      description: Modules or paths likely involved. Leave unknown if not established.
+    validations:
+      required: true
+
+  - type: textarea
+    id: regression
+    attributes:
+      label: Required regression test
+      description: Describe the test that should fail before the fix and pass after it.
+    validations:
+      required: true

--- a/fitness-app/.github/ISSUE_TEMPLATE/feature.yml
+++ b/fitness-app/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,105 @@
+name: Feature
+
+description: Plan a bounded product or engineering feature
+
+title: "[FEATURE] "
+
+labels: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Define the work narrowly enough that one owner can implement and validate it without inventing missing requirements.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this needed? Link relevant specs, ADRs, issues or discussions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: State the observable outcome, not the implementation activity.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What must be implemented in this issue?
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicitly list adjacent work that must not be included.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Other issues, contracts, ADRs or prerequisites. Write None if there are none.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: owner
+    attributes:
+      label: Primary engineering owner
+      options:
+        - project_manager
+        - tech_lead
+        - backend_engineer
+        - mobile_engineer
+        - data_engineer
+        - qa_engineer
+        - devops_engineer
+        - security_engineer
+        - cross-functional
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected_modules
+    attributes:
+      label: Expected affected modules
+      description: Repository paths or logical modules that are expected to change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use a checkable list of externally verifiable outcomes.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Required validation and tests
+      description: State unit, integration, E2E, migration, security, or manual verification requirements.
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and review gates
+      description: Note data, architecture, security, migration, compatibility or rollout risks. Identify required specialist reviews.
+    validations:
+      required: true

--- a/fitness-app/.github/pull_request_template.md
+++ b/fitness-app/.github/pull_request_template.md
@@ -1,0 +1,67 @@
+## Summary
+
+Describe the single primary change introduced by this Pull Request.
+
+## Related Issue
+
+Closes #
+
+## Scope
+
+- 
+
+## Out of scope
+
+- 
+
+## Architecture / contracts
+
+- [ ] No architectural decision changed
+- [ ] No public API contract changed
+- [ ] No structural database migration added
+
+If any box above is false, explain the approved ADR, contract change, or migration dependency:
+
+## Validation
+
+List the exact commands/checks run and their results.
+
+```text
+
+```
+
+## Test coverage
+
+- [ ] Relevant unit tests added/updated
+- [ ] Relevant integration tests added/updated
+- [ ] Relevant mobile/component/E2E tests added/updated where applicable
+- [ ] Regression test included for bug fixes
+
+Not applicable items must be explained below.
+
+## Risk checklist
+
+- [ ] No secrets or privileged credentials committed
+- [ ] No unrelated files changed
+- [ ] Authorization/privacy impact reviewed where applicable
+- [ ] Data migration/data-loss risk reviewed where applicable
+- [ ] Offline/synchronization behavior reviewed where applicable
+- [ ] Backwards compatibility considered
+
+## Required reviewers
+
+Indicate specialist review when applicable:
+- `tech_lead` for architectural or cross-module changes
+- `data_engineer` for structural database changes
+- `security_engineer` for auth/privacy/security-sensitive changes
+- `qa_engineer` for independent acceptance/regression verification
+
+## Acceptance criteria
+
+Copy or reference the Issue acceptance criteria and mark only items actually verified.
+
+- [ ]
+
+## Remaining limitations / follow-up
+
+State anything intentionally deferred or not validated. Write `None` if complete.

--- a/fitness-app/docs/architecture/README.md
+++ b/fitness-app/docs/architecture/README.md
@@ -1,0 +1,47 @@
+# Architecture Documentation
+
+This directory is the source of truth for system-wide technical decisions.
+
+## Baseline architecture
+
+Keylornet is designed as a modular monolith with a mobile client and a server-side API:
+
+```text
+React Native / Expo / TypeScript
+            |
+            | HTTPS / REST / JWT
+            v
+      FastAPI backend
+            |
+            v
+ PostgreSQL / Supabase
+```
+
+Supporting services:
+- Supabase Auth for identity
+- Supabase Storage for user media
+- Expo Notifications for push notifications
+- Expo SQLite for mobile offline persistence
+- Docker for reproducible development/deployment
+- GitHub Actions for CI/CD
+
+## Architectural principles
+
+1. Prefer a modular monolith over microservices until a concrete scaling or organizational requirement justifies separation.
+2. PostgreSQL is the persistent source of truth for server-side business data.
+3. Raw workout data is authoritative; analytics and rankings must be reproducible from it.
+4. Critical business rules and authorization live server-side.
+5. The mobile client is offline-capable but is not authoritative for derived statistics or security decisions.
+6. API contracts are explicit and versioned through OpenAPI.
+7. Structural database changes require migrations and data-integrity review.
+8. Security and privacy are design concerns, not post-release add-ons.
+9. Prefer simple infrastructure until complexity is demonstrated to be necessary.
+
+## Documentation map
+
+- `adr/`: Architecture Decision Records.
+- `../design-docs/`: implementation-oriented designs for bounded features or subsystems.
+- `../product-specs/`: product requirements and behavior.
+- `../exec-plans/`: implementation plans for milestones and complex changes.
+
+If a proposed change materially alters an architectural principle, create or update an ADR before implementation.

--- a/fitness-app/docs/architecture/adr/ADR-001-modular-monolith.md
+++ b/fitness-app/docs/architecture/adr/ADR-001-modular-monolith.md
@@ -1,0 +1,47 @@
+# ADR-001: Modular Monolith Architecture
+
+- Status: Accepted
+- Date: 2026-08-28
+
+## Context
+
+The product requires a mobile application, authenticated APIs, relational workout data, analytics, rankings, social features, media, and future integrations. The system is at project inception and does not yet have scale or team boundaries that justify distributed services.
+
+## Decision
+
+Use a modular monolith for the backend.
+
+Primary modules will include:
+- auth
+- users
+- exercises
+- workouts
+- analytics
+- groups
+- rankings
+- social
+- media
+- notifications
+
+The mobile application remains a separate client. Backend modules communicate in-process and share one PostgreSQL database while maintaining explicit domain boundaries.
+
+## Consequences
+
+Positive:
+- lower operational complexity
+- simpler local development and testing
+- easier transactions across related domains
+- faster initial delivery
+- clear future extraction boundaries if required
+
+Trade-offs:
+- module boundaries must be enforced by code organization and review
+- poor discipline could lead to unwanted coupling
+
+## Rejected alternatives
+
+### Microservices
+Rejected at inception because they add deployment, networking, observability, consistency, and coordination costs without a demonstrated requirement.
+
+### Backend-as-a-service-only architecture
+Rejected as the sole architecture because core business rules, rankings, authorization, offline synchronization semantics, and future analytics require an explicit server-side application layer.

--- a/fitness-app/docs/architecture/adr/ADR-002-authentication-and-authorization.md
+++ b/fitness-app/docs/architecture/adr/ADR-002-authentication-and-authorization.md
@@ -1,0 +1,35 @@
+# ADR-002: Authentication and Authorization
+
+- Status: Accepted
+- Date: 2026-08-28
+
+## Context
+
+The application requires user registration, login, groups, private/public content, media, rankings and future account deletion/export flows. Client-side checks cannot be trusted for authorization.
+
+## Decision
+
+Use Supabase Auth for identity and token issuance. The FastAPI backend validates JWTs and performs server-side authorization for protected business operations.
+
+Rules:
+- authentication establishes identity
+- authorization is evaluated server-side for every protected resource
+- ownership and group membership are never trusted from the mobile client
+- privileged Supabase/service-role credentials remain server-side only
+- Row Level Security is used where Supabase Data API access exists
+- public, group and private visibility rules must be explicit
+
+## Consequences
+
+Positive:
+- avoids implementing password and identity infrastructure from scratch
+- preserves a clear backend authorization boundary
+- supports future OAuth providers
+
+Trade-offs:
+- integration depends on Supabase identity semantics
+- RLS policies and backend authorization must remain consistent
+
+## Security invariant
+
+A user must never gain access to another user's protected resource merely by changing an identifier in a client request.

--- a/fitness-app/docs/architecture/adr/ADR-003-offline-first-mobile.md
+++ b/fitness-app/docs/architecture/adr/ADR-003-offline-first-mobile.md
@@ -1,0 +1,40 @@
+# ADR-003: Offline-First Workout Recording
+
+- Status: Accepted
+- Date: 2026-08-28
+
+## Context
+
+Gym environments may have unreliable connectivity. Recording a set is a high-frequency user action and must not depend on a successful round trip to the backend.
+
+## Decision
+
+Use Expo SQLite as local persistence for active workout flows. User actions are persisted locally first and synchronized with the backend when connectivity permits.
+
+The detailed synchronization protocol will be defined in a dedicated design document before implementation.
+
+Required properties:
+- workout recording remains usable offline
+- local persistence survives application restarts
+- synchronization status is observable
+- failed writes are retryable when appropriate
+- duplicate remote mutations are prevented through explicit idempotency semantics
+- conflict behavior is defined rather than implicit
+- the UI must distinguish local success from remote synchronization success where material
+
+## Authority
+
+Local mobile data may temporarily contain newer user input, but PostgreSQL remains the persistent server-side source of truth after successful synchronization.
+
+Derived rankings and authoritative analytics are computed server-side.
+
+## Consequences
+
+Positive:
+- robust gym experience
+- reduced perceived latency
+- recovery from temporary network loss
+
+Trade-offs:
+- synchronization and conflict handling add complexity
+- mutations require stable identifiers and idempotent behavior

--- a/fitness-app/docs/architecture/adr/ADR-TEMPLATE.md
+++ b/fitness-app/docs/architecture/adr/ADR-TEMPLATE.md
@@ -1,0 +1,38 @@
+# ADR-NNN: Decision title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Decision owners: `tech_lead`
+
+## Context
+
+Describe the problem, constraints, existing architecture and why a durable architectural decision is required.
+
+## Decision
+
+State the decision precisely. Separate required behavior from implementation detail where possible.
+
+## Consequences
+
+### Positive
+- 
+
+### Trade-offs / risks
+- 
+
+## Alternatives considered
+
+### Alternative 1
+Describe the alternative and why it was not selected.
+
+## Compatibility / migration
+
+Describe impact on existing APIs, data, mobile clients, deployments or migrations. Write `None` if not applicable.
+
+## Security and privacy impact
+
+Describe material impact or state `None`.
+
+## Follow-up
+
+List required design documents, Issues or implementation work.

--- a/fitness-app/docs/design-docs/README.md
+++ b/fitness-app/docs/design-docs/README.md
@@ -1,0 +1,38 @@
+# Design Documents
+
+Use this directory for implementation-oriented designs that are narrower than an ADR but substantial enough that agents should not invent behavior while coding.
+
+A design document is appropriate for topics such as:
+- offline synchronization protocol
+- workout domain model
+- exercise catalog import/normalization
+- ranking methodology
+- media upload flow
+- notification workflow
+- API versioning details
+
+## Suggested structure
+
+```text
+# Title
+
+## Problem
+## Goals
+## Non-goals
+## Domain model
+## API / interface contract
+## Data model
+## Failure modes and edge cases
+## Security / privacy
+## Testing strategy
+## Rollout / migration
+## Open questions
+```
+
+## Rules
+
+- Reference relevant ADRs and product specifications.
+- Do not use a design document to silently reverse an accepted ADR.
+- Resolve material open questions before assigning implementation work.
+- API, persistence, synchronization and ranking behavior must be explicit enough that independent agents can implement against the same contract.
+- Keep implementation-specific details current as the design evolves.

--- a/fitness-app/docs/exec-plans/M0-engineering-foundation.md
+++ b/fitness-app/docs/exec-plans/M0-engineering-foundation.md
@@ -1,0 +1,176 @@
+# M0 Engineering Foundation
+
+- Status: Planned
+- Milestone: M0
+- Owner: Project Manager
+
+## Objective
+
+Establish a reproducible engineering foundation before product feature implementation begins.
+
+The milestone is complete when a new contributor or Codex worktree can clone the repository, start the backend/database/mobile development environment, run validation locally, and open a Pull Request that is checked automatically.
+
+## Workstreams
+
+### FND-001 Architecture conventions
+Owner: `tech_lead`
+
+Deliverables:
+- architecture documentation structure
+- initial ADRs
+- API and repository conventions
+
+### FND-002 GitHub contribution model
+Owner: `project_manager` + `devops_engineer`
+
+Deliverables:
+- Issue templates
+- Pull Request template
+- labels/taxonomy plan
+- branch/PR workflow
+
+### FND-003 FastAPI skeleton
+Owner: `backend_engineer`
+
+Deliverables:
+- application entry point
+- configuration structure
+- `/health` endpoint
+- test skeleton
+- formatting/lint/type-check configuration
+
+Dependencies: FND-001
+
+### FND-004 Expo mobile skeleton
+Owner: `mobile_engineer`
+
+Deliverables:
+- Expo application
+- TypeScript strict configuration
+- Expo Router baseline
+- environment configuration
+- API connectivity abstraction
+- test skeleton
+
+Dependencies: FND-001
+
+### FND-005 PostgreSQL and Alembic baseline
+Owner: `data_engineer`
+
+Deliverables:
+- database configuration
+- Alembic baseline
+- migration conventions
+- test database strategy
+
+Dependencies: FND-001
+
+### FND-006 Local Docker environment
+Owner: `devops_engineer`
+
+Deliverables:
+- reproducible local services
+- environment-variable examples
+- documented startup workflow
+
+Dependencies: FND-003, FND-005 as required by implementation choices
+
+### FND-007 Backend CI
+Owner: `devops_engineer`
+
+Deliverables:
+- backend lint/format/type/test checks
+- deterministic check names for branch protection
+
+Dependencies: FND-003
+
+### FND-008 Mobile CI
+Owner: `devops_engineer`
+
+Deliverables:
+- mobile lint/type/test checks
+- deterministic check names for branch protection
+
+Dependencies: FND-004
+
+### FND-009 Database migration CI
+Owner: `devops_engineer` + `data_engineer`
+
+Deliverables:
+- migration validation against test PostgreSQL
+
+Dependencies: FND-005
+
+### FND-010 Mobile-to-API health integration
+Owner: `mobile_engineer` + `backend_engineer`
+
+Acceptance path:
+
+```text
+Mobile -> GET /health -> FastAPI -> 200 -> visible development status
+```
+
+Dependencies: FND-003, FND-004, FND-006
+
+### FND-011 Test architecture
+Owner: `qa_engineer`
+
+Deliverables:
+- test taxonomy
+- required test locations
+- integration test strategy
+- initial smoke path
+
+Dependencies: FND-003, FND-004, FND-005
+
+### FND-012 Branch protection
+Owner: `project_manager` + `devops_engineer`
+
+Deliverables:
+- `main` protected
+- Pull Request required
+- real CI checks required
+- no direct pushes as normal workflow
+
+Dependencies: FND-007, FND-008, FND-009
+
+## Parallelization plan
+
+After FND-001 is accepted, the following can proceed in separate worktrees:
+
+```text
+FND-003 FastAPI       \
+FND-004 Expo           > parallel
+FND-005 Database      /
+```
+
+FND-006 can then integrate the backend/database local environment. CI work begins once each corresponding skeleton has a stable validation command.
+
+Do not assign multiple write-heavy agents to the same checkout for these workstreams.
+
+## Milestone gate
+
+M0 is complete only when all of the following are true:
+- local setup is documented and reproducible
+- backend starts successfully
+- mobile app starts successfully
+- PostgreSQL test/development integration works
+- backend health endpoint returns success
+- mobile can call the backend health endpoint in the supported development setup
+- automated backend checks pass
+- automated mobile checks pass
+- migration checks pass
+- `main` is protected using the actual CI check names
+- no privileged secrets are committed
+- QA has independently verified the foundation smoke path
+
+## Explicit non-goals
+
+M0 does not implement:
+- authentication product flows
+- exercise catalog
+- workout domain
+- rankings
+- social features
+
+Those belong to later milestones.

--- a/fitness-app/docs/product-specs/MVP.md
+++ b/fitness-app/docs/product-specs/MVP.md
@@ -1,0 +1,98 @@
+# Keylornet MVP Product Specification
+
+## Product goal
+
+Keylornet is a mobile application for recording gym training, reviewing personal history and progress, and comparing activity and performance within groups. Social sharing is a later layer built on top of trustworthy workout data.
+
+## MVP priorities
+
+The first usable product must prioritize reliable workout recording over social functionality.
+
+### 1. Identity
+Users can:
+- register
+- log in and log out
+- recover access
+- maintain a basic profile
+- delete their account according to the defined privacy flow
+
+### 2. Exercise catalog
+Users can:
+- search exercises
+- filter by muscle and equipment
+- inspect instructions and exercise metadata
+- create private/custom exercises where supported
+
+An exercise can target multiple muscles with explicit roles such as primary and secondary.
+
+### 3. Workout recording
+Users can:
+- start a workout session
+- add exercises
+- add, edit and remove sets
+- record repetitions and weight where applicable
+- add comments
+- finish or cancel a session
+- continue recording when network connectivity is unavailable
+
+The data model must allow future exercise metrics such as duration, distance, assistance and other exercise-specific values without requiring a destructive redesign.
+
+### 4. History and personal analytics
+Users can:
+- inspect historical sessions
+- inspect exercise progression
+- see personal records
+- see training frequency
+- see volume statistics where meaningful
+- see estimated 1RM for supported strength exercises
+
+Raw workout data is the source of truth for derived metrics.
+
+### 5. Groups and rankings
+Users can:
+- create or join groups
+- view group membership
+- compare weekly, monthly and yearly training frequency
+- compare performance by compatible exercise
+- view aggregate muscle scores once methodology is implemented and documented
+
+Arbitrary machine weights must not be treated as universally comparable strength values.
+
+## Post-MVP / later milestones
+
+- social posts
+- workout sharing
+- photos and media
+- reactions and comments
+- push notifications
+- routine/templates
+- advanced analytics
+- Apple Health / Health Connect / Garmin integrations
+- recommendation systems
+
+These later features must not block delivery of the workout core.
+
+## Privacy model
+
+The architecture must support explicit visibility levels where relevant:
+- PRIVATE
+- GROUP
+- PUBLIC
+
+Client-side visibility controls are not sufficient authorization.
+
+## Product quality constraints
+
+- workout entry must remain practical with unreliable connectivity
+- common set-entry actions should require minimal interaction
+- data loss during recoverable network failures is unacceptable
+- derived statistics must be reproducible
+- security and privacy requirements apply from the first release
+
+## Out of scope for initial implementation
+
+- microservices
+- real-time global social feed at scale
+- complex recommendation/AI coaching
+- payment/subscription system
+- direct support for minors unless requirements are explicitly revisited


### PR DESCRIPTION
## Summary

Establishes the documentation and GitHub work-contract layer required before implementation agents start writing product code.

## Scope

- architecture documentation index
- accepted ADRs for modular-monolith architecture, auth/authorization, and offline-first workout recording
- reusable ADR template
- MVP product specification
- M0 Engineering Foundation execution plan
- design-document guidance
- feature Issue template
- bug Issue template
- Pull Request template

## Intent

This makes repository documentation the durable source of truth for Codex agents and future contributors. It narrows implementation ambiguity before FastAPI, Expo, PostgreSQL and CI work begin.

## Validation

- branch contains documentation/templates only
- no production code changed
- no infrastructure behavior changed
- no migrations added
- no secrets added
- M0 plan explicitly defines dependencies and parallelizable workstreams

## Follow-up

After this PR is reviewed/merged, create the actual FND backlog and begin the first Codex worktree phase:
- FND-003 FastAPI skeleton
- FND-004 Expo skeleton
- FND-005 PostgreSQL/Alembic baseline

Those implementation tracks should run in separate Codex worktrees after the corresponding Issues are created.