### PR TITLE
chore: version M0 task specifications for Codex

### DIFF
--- a/docs/exec-plans/tasks/FND-003-fastapi-backend-skeleton.md
+++ b/docs/exec-plans/tasks/FND-003-fastapi-backend-skeleton.md
@@ -1,0 +1,79 @@
+# FND-003 — Create FastAPI backend skeleton
+
+## Status
+
+Ready for implementation.
+
+## Primary owner
+
+`backend_engineer`
+
+## Context
+
+The architecture baseline is accepted and M0 now needs an executable backend foundation before product-domain implementation begins.
+
+## Goal
+
+Create a minimal, production-oriented FastAPI application skeleton with a health endpoint and automated local validation commands.
+
+## Scope
+
+- create backend project under `services/api/`
+- FastAPI application entry point
+- typed configuration/settings structure
+- `/health` endpoint returning a stable success contract
+- baseline logging/config organization
+- pytest test skeleton and health endpoint test
+- formatting, linting and static type-check configuration
+- local developer commands documented in the backend README or equivalent
+
+## Out of scope
+
+- authentication implementation
+- database domain models
+- Alembic structural migrations
+- exercise/workout/group/social APIs
+- deployment/CI workflows
+
+## Dependencies
+
+- FND-001 completed
+- FND-002 completed
+
+## Expected affected modules
+
+- `services/api/`
+
+## Acceptance criteria
+
+- [ ] backend starts locally using the documented command
+- [ ] `GET /health` returns HTTP 200 with a stable JSON response
+- [ ] application configuration is typed and environment-driven
+- [ ] no secrets are committed
+- [ ] pytest includes a passing health endpoint test
+- [ ] formatting/lint/type-check commands are configured and documented
+- [ ] package/dependency declarations are reproducible
+- [ ] no product-domain functionality is introduced
+
+## Required validation
+
+- run backend test suite
+- run formatter/linter in check mode
+- run static type checking
+- start application and verify `/health`
+
+## Review gates
+
+- use `tech_lead` for read-only review if a different backend layering or dependency-management strategy is proposed
+- do not create structural database migrations
+- do not change repository-wide architecture
+- use `qa_engineer` for independent verification after implementation
+
+## Codex execution rules
+
+- work in an isolated worktree/branch dedicated to FND-003
+- do not modify `main`
+- stay within `services/api/`
+- inspect the complete diff before completion
+- do not require GitHub CLI access to begin implementation
+- if remote push/PR creation is unavailable in the sandbox, finish with a clean local commit and report the branch name and commit SHA for external publication

--- a/docs/exec-plans/tasks/FND-004-expo-mobile-skeleton.md
+++ b/docs/exec-plans/tasks/FND-004-expo-mobile-skeleton.md
@@ -1,0 +1,81 @@
+# FND-004 — Create Expo mobile skeleton
+
+## Status
+
+Ready for implementation.
+
+## Primary owner
+
+`mobile_engineer`
+
+## Context
+
+The mobile architecture is accepted and M0 needs a reproducible Expo/React Native foundation before product screens are implemented.
+
+## Goal
+
+Create a minimal Expo + TypeScript application skeleton with routing, environment configuration, API connectivity abstraction and test/type/lint foundations.
+
+## Scope
+
+- create mobile project under `apps/mobile/`
+- Expo + React Native + TypeScript
+- TypeScript strict mode
+- Expo Router baseline
+- environment configuration pattern
+- API client/connectivity abstraction without inventing product contracts
+- simple development screen suitable for later `/health` integration
+- baseline unit/component test setup
+- formatting/lint/type-check configuration
+- local developer commands documented
+
+## Out of scope
+
+- authentication UI
+- exercise/workout/social screens
+- SQLite synchronization implementation beyond any minimal project dependency setup
+- production design system
+- CI/EAS deployment workflows
+
+## Dependencies
+
+- FND-001 completed
+- FND-002 completed
+
+## Expected affected modules
+
+- `apps/mobile/`
+
+## Acceptance criteria
+
+- [ ] Expo application starts using the documented command
+- [ ] TypeScript strict mode is enabled
+- [ ] Expo Router is configured with a minimal route structure
+- [ ] environment-specific API base URL can be configured without hard-coding production values
+- [ ] no secrets are committed
+- [ ] baseline tests execute successfully
+- [ ] formatting/lint/type-check commands are configured and documented
+- [ ] no product-domain screens or invented API contracts are introduced
+
+## Required validation
+
+- run TypeScript checks
+- run lint/format checks
+- run mobile tests
+- start Expo development application successfully
+
+## Review gates
+
+- use `tech_lead` for read-only review if replacing the agreed routing/state/tooling baseline is proposed
+- do not implement authoritative business rules client-side
+- do not modify backend/database/infrastructure areas
+- use `qa_engineer` for independent verification after implementation
+
+## Codex execution rules
+
+- work in an isolated worktree/branch dedicated to FND-004
+- do not modify `main`
+- stay within `apps/mobile/`
+- inspect the complete diff before completion
+- do not require GitHub CLI access to begin implementation
+- if remote push/PR creation is unavailable in the sandbox, finish with a clean local commit and report the branch name and commit SHA for external publication

--- a/docs/exec-plans/tasks/FND-005-postgresql-alembic-baseline.md
+++ b/docs/exec-plans/tasks/FND-005-postgresql-alembic-baseline.md
@@ -1,0 +1,78 @@
+# FND-005 — Establish PostgreSQL and Alembic baseline
+
+## Status
+
+Ready for implementation.
+
+## Primary owner
+
+`data_engineer`
+
+## Context
+
+M0 needs a reproducible database foundation before domain tables and product migrations are introduced.
+
+## Goal
+
+Create the PostgreSQL/Alembic baseline, migration conventions and test-database strategy without defining product-domain schema yet.
+
+## Scope
+
+- create database project/configuration under `database/`
+- PostgreSQL connection/config pattern using environment variables
+- Alembic initialization and migration conventions
+- baseline migration strategy suitable for later SQLAlchemy integration
+- test database strategy and documented local commands
+- validation that migrations can be applied from a clean database state
+
+## Out of scope
+
+- users/profiles/workouts/exercises/groups/social domain tables
+- Supabase production provisioning
+- authentication/RLS policies
+- ranking/analytics schema
+- CI workflow implementation
+
+## Dependencies
+
+- FND-001 completed
+- FND-002 completed
+
+## Expected affected modules
+
+- `database/`
+- only minimal backend integration points if strictly required and explicitly documented
+
+## Acceptance criteria
+
+- [ ] Alembic is initialized and has documented conventions
+- [ ] database connection settings are environment-driven
+- [ ] no credentials or secrets are committed
+- [ ] a clean local/test PostgreSQL database can run the baseline migration path successfully
+- [ ] migration validation commands are documented
+- [ ] test database strategy is documented
+- [ ] no product-domain tables are introduced
+- [ ] destructive migration behavior is not introduced
+
+## Required validation
+
+- initialize a clean PostgreSQL test database
+- run Alembic upgrade through the baseline
+- verify current/head state
+- verify configuration fails safely when required environment settings are missing or invalid as appropriate
+
+## Review gates
+
+- structural migrations are owned by `data_engineer`
+- use `tech_lead` for read-only review if changing persistence architecture or ORM/migration boundaries is proposed
+- coordinate with FND-003 only where backend/database configuration must align
+- use `qa_engineer` for independent migration verification after implementation
+
+## Codex execution rules
+
+- work in an isolated worktree/branch dedicated to FND-005
+- do not modify `main`
+- primary write scope is `database/`
+- inspect the complete diff before completion
+- do not require GitHub CLI access to begin implementation
+- if remote push/PR creation is unavailable in the sandbox, finish with a clean local commit and report the branch name and commit SHA for external publication

--- a/docs/exec-plans/tasks/README.md
+++ b/docs/exec-plans/tasks/README.md
@@ -1,0 +1,20 @@
+# Codex Task Specifications
+
+These files mirror active implementation work that is also tracked in GitHub Issues.
+
+## Purpose
+
+Codex implementation agents must be able to execute from repository-local context even when GitHub CLI or remote network authentication is unavailable inside a sandboxed worktree.
+
+For implementation work, the local task specification is the execution contract for scope, acceptance criteria, validation, ownership and boundaries. GitHub remains the project-management record for status, discussion and Pull Requests.
+
+## Rules
+
+- Read the repository `AGENTS.md` hierarchy before executing a task.
+- Read the relevant architecture documents and accepted ADRs.
+- Use the task file matching the assigned FND identifier.
+- Do not broaden scope based on assumptions.
+- If a local task specification conflicts with an accepted ADR, stop and escalate to `tech_lead`.
+- If GitHub is accessible, compare the local task spec with the Issue and report any discrepancy; GitHub access is not a prerequisite for implementation.
+- Codex must not expose, request, copy or persist GitHub authentication tokens in project files.
+- Remote push and Pull Request creation may be performed outside the Codex sandbox when the sandbox cannot authenticate reliably.


### PR DESCRIPTION
## Summary

Adds repository-local execution specifications for FND-003, FND-004 and FND-005 so Codex agents can work from durable local context even when GitHub CLI authentication is unavailable inside the Windows sandbox.

## Scope

- `docs/exec-plans/tasks/README.md`
- `docs/exec-plans/tasks/FND-003-fastapi-backend-skeleton.md`
- `docs/exec-plans/tasks/FND-004-expo-mobile-skeleton.md`
- `docs/exec-plans/tasks/FND-005-postgresql-alembic-baseline.md`

## Intent

GitHub remains the project-management record, while Codex implementation no longer depends on `gh issue view` or remote API access from its sandbox. If remote push/PR creation also fails, agents are instructed to finish with a clean local branch/commit for publication outside Codex.

## Validation

Documentation only; no production code, migrations or runtime configuration changed.