### PR TITLE
chore: use supported Terra model for Codex agents

### DIFF
--- a/.codex/agents/backend-engineer.toml
+++ b/.codex/agents/backend-engineer.toml
@@ -7,7 +7,7 @@ REST APIs, authentication integration, application services and repositories.
 Primary ownership is services/api/.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 

--- a/.codex/agents/data-engineer.toml
+++ b/.codex/agents/data-engineer.toml
@@ -7,7 +7,7 @@ Use for schema design, indexes, constraints, migrations, seeds, rankings,
 statistics and data integrity.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 

--- a/.codex/agents/devops-engineer.toml
+++ b/.codex/agents/devops-engineer.toml
@@ -7,7 +7,7 @@ environments, deployment, infrastructure, observability and repository
 automation. Primary ownership is infra/ and .github/.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 

--- a/.codex/agents/mobile-engineer.toml
+++ b/.codex/agents/mobile-engineer.toml
@@ -7,7 +7,7 @@ Expo Router, TanStack Query, Zustand, SQLite, forms, offline workflows,
 mobile UX and API integration. Primary ownership is apps/mobile/.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 

--- a/.codex/agents/project-manager.toml
+++ b/.codex/agents/project-manager.toml
@@ -8,7 +8,7 @@ coordination between engineering agents, and progress assessment.
 Do not use for implementation.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 

--- a/.codex/agents/security-engineer.toml
+++ b/.codex/agents/security-engineer.toml
@@ -7,7 +7,7 @@ authorization, Supabase RLS, privacy, file uploads, secrets, API exposure,
 GDPR-related technical controls and security review of sensitive changes.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 

--- a/.codex/agents/tech-lead.toml
+++ b/.codex/agents/tech-lead.toml
@@ -7,7 +7,7 @@ decisions, API contracts, cross-module changes, design reviews, ADR analysis,
 technical debt assessment, and final technical review of important PRs.
 """
 
-model = "gpt-5.6"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 


### PR DESCRIPTION
## Summary
Align project custom agents with the Codex model that is actually available in the current ChatGPT-authenticated environment.

## Why
`backend_engineer`, `data_engineer` and `tech_lead` failed to start because their explicit `gpt-5.6` model override was unavailable, while `qa_engineer` using `gpt-5.6-terra` succeeded. The repository default subagent model is already `gpt-5.6-terra`.

## Scope
Update the explicit model override to `gpt-5.6-terra` for all custom agents that currently use `gpt-5.6`. No developer instructions, permissions or ownership rules change.

## Validation
Configuration-only change; no runtime application code is affected.