### PR TITLE
FND-007 — Add backend CI checks

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,52 @@
+name: Backend CI
+
+on:
+  pull_request:
+    paths:
+      - "services/api/**"
+      - ".github/workflows/backend-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "services/api/**"
+      - ".github/workflows/backend-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend-ci:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/api
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: services/api/constraints.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -c constraints.txt -e ".[dev]"
+          python -m pip check
+
+      - name: Check formatting
+        run: ruff format --check .
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Type check
+        run: mypy app
+
+      - name: Test
+        run: pytest

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -64,3 +64,9 @@ ruff check .
 mypy app
 pytest
 ```
+
+## Continuous integration
+
+The GitHub Actions workflow runs the same validation commands on pull requests
+that affect `services/api/` and on pushes to `main`. Its stable job/check name
+for branch protection is `Backend CI`.


### PR DESCRIPTION
## Summary

Adds a deterministic backend validation workflow for FND-007.

## Related Issue

Closes #16

## Scope

- Adds `.github/workflows/backend-ci.yml` for backend-relevant pull requests and pushes to `main`.
- Installs `services/api` with its committed `constraints.txt` and runs the authoritative local commands: format check, lint, mypy, and pytest.
- Documents the stable branch-protection check name: `Backend CI`.

## Out of scope

- Database and mobile CI, deployment, coverage gates, and product functionality.

## Architecture / contracts

- [x] No architectural decision changed
- [x] No public API contract changed
- [x] No structural database migration added

## Validation

```text
python -m pip install -c constraints.txt -e ".[dev]"  # OK
python -m pip check                                  # OK
ruff format --check .                                # OK
ruff check .                                         # OK
mypy app                                              # OK
pytest                                                # 4 passed
YAML parse                                            # OK
GitHub Actions: Backend CI (run #1)                  # success
```

GitHub Actions verified the `Backend CI` job and all of its required steps: constrained install, formatting, lint, type check, and tests.

## Risks / security

- [x] No secrets or privileged credentials committed
- [x] Workflow permissions are limited to `contents: read`
- [x] No unrelated files changed

## Acceptance criteria

- [x] Backend-relevant pull requests trigger the workflow
- [x] Reproducible constrained installation is configured
- [x] Format, lint, mypy, and pytest are configured
- [x] Stable check name is documented
- [x] No secrets are required
- [x] GitHub Actions run confirmed green

## Remaining limitations / follow-up

Draft pending independent QA before being marked ready for review.