### PR TITLE
feat(infra): add local PostgreSQL Docker environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Local-only PostgreSQL defaults. These are intentionally non-production values.
+# Copy to .env before starting Compose, then change the port only if 5432 is busy.
+KEYLORNET_POSTGRES_USER=keylornet
+KEYLORNET_POSTGRES_PASSWORD=keylornet_local_development_only
+KEYLORNET_POSTGRES_DB=keylornet
+KEYLORNET_POSTGRES_TEST_DB=keylornet_test
+KEYLORNET_POSTGRES_PORT=5432

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Docker entrypoint scripts run inside Linux containers and require LF endings.
+infra/docker/postgres/init/*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Developer-specific local Docker configuration. Never commit credentials.
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # keylornet
+
+## Local PostgreSQL
+
+The reproducible local PostgreSQL 17 environment, including start, migration
+validation, stop, and explicit reset instructions, is documented in
+[infra/README.md](infra/README.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,23 @@
-version: '3.8'
-
 services:
-  # Add your services here
+  postgres:
+    image: postgres:17.6-alpine
+    environment:
+      POSTGRES_USER: ${KEYLORNET_POSTGRES_USER:-keylornet}
+      POSTGRES_PASSWORD: ${KEYLORNET_POSTGRES_PASSWORD:-keylornet_local_development_only}
+      POSTGRES_DB: ${KEYLORNET_POSTGRES_DB:-keylornet}
+      KEYLORNET_POSTGRES_TEST_DB: ${KEYLORNET_POSTGRES_TEST_DB:-keylornet_test}
+    ports:
+      - "127.0.0.1:${KEYLORNET_POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - keylornet_postgres_data:/var/lib/postgresql/data
+      - ./infra/docker/postgres/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  keylornet_postgres_data:

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,77 @@
+# Local Docker environment
+
+This Compose environment provides only the local PostgreSQL 17 service needed
+by the backend and database foundations. It does not package or deploy the API,
+mobile app, Supabase, or any product service.
+
+The local development database is `keylornet`; the separately provisioned
+disposable migration-test database is `keylornet_test`. Database clients must
+use the repository's sole supported SQLAlchemy driver contract:
+`postgresql+psycopg://` (psycopg 3).
+
+## Start
+
+From the repository root, create an untracked local configuration and start
+PostgreSQL:
+
+```powershell
+Copy-Item .env.example .env
+docker compose up -d
+docker compose ps
+docker compose exec postgres pg_isready -U keylornet -d keylornet
+```
+
+The default port is bound to `127.0.0.1` only. The checked-in password is a
+deliberately non-production local default, not a credential for any shared
+environment. Do not reuse it outside a disposable local checkout.
+
+The first start of a fresh named volume creates both databases. The test
+database name is required to end in `_test`; this mirrors the guard in the
+database migration tests.
+
+## Database validation
+
+Install the pinned database dependencies and then apply the baseline to the
+development database:
+
+```powershell
+Set-Location database
+python -m pip install -c constraints.txt -e '.[dev]'
+$env:KEYLORNET_ENVIRONMENT = 'development'
+$env:KEYLORNET_DATABASE_URL = 'postgresql+psycopg://keylornet:keylornet_local_development_only@127.0.0.1:5432/keylornet'
+python -m alembic upgrade head
+python -m alembic current
+```
+
+Validate the clean migration path with the separate test database before it
+has received any migrations:
+
+```powershell
+$env:KEYLORNET_TEST_DATABASE_URL = 'postgresql+psycopg://keylornet:keylornet_local_development_only@127.0.0.1:5432/keylornet_test'
+pytest
+```
+
+If you changed values in `.env`, use the corresponding values in these URLs.
+Never use a development, staging, or production database as the test target.
+
+## Stop and reset
+
+Stop while retaining local data:
+
+```powershell
+docker compose down
+```
+
+Reset is destructive to the local named volume and therefore explicit. It
+recreates empty `keylornet` and `keylornet_test` databases on the next start:
+
+```powershell
+docker compose down --volumes
+docker compose up -d
+```
+
+## Backend health
+
+The API currently runs on the host rather than in this Compose stack. Follow
+`services/api/README.md` to start it, then verify its independent health
+contract with `Invoke-RestMethod http://127.0.0.1:8000/health`.

--- a/infra/docker/postgres/init/10-create-test-database.sh
+++ b/infra/docker/postgres/init/10-create-test-database.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+test_database="${KEYLORNET_POSTGRES_TEST_DB:?KEYLORNET_POSTGRES_TEST_DB is required}"
+
+case "$test_database" in
+  *_test) ;;
+  *)
+    echo "KEYLORNET_POSTGRES_TEST_DB must end in _test" >&2
+    exit 1
+    ;;
+esac
+
+escaped_database=$(printf '%s' "$test_database" | sed 's/"/""/g')
+escaped_owner=$(printf '%s' "$POSTGRES_USER" | sed 's/"/""/g')
+
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --set=ON_ERROR_STOP=1 \
+  --command "CREATE DATABASE \"$escaped_database\" OWNER \"$escaped_owner\";"

--- a/infra/docker/postgres/init/10-create-test-database.sh
+++ b/infra/docker/postgres/init/10-create-test-database.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# This script is mounted into a Linux PostgreSQL container; retain LF endings.
 set -eu
 
 test_database="${KEYLORNET_POSTGRES_TEST_DB:?KEYLORNET_POSTGRES_TEST_DB is required}"


### PR DESCRIPTION
## Summary

- replace the placeholder Compose file with a pinned PostgreSQL 17.6 local service
- provide isolated localhost-only exposure, health checks, named-volume persistence, and deterministic `keylornet` / `keylornet_test` initialization
- document safe local configuration, start/stop/reset, and real Alembic validation using the explicit `postgresql+psycopg://` driver contract

## Validation

- `docker compose config --quiet`
- clean Docker Compose startup with PostgreSQL health check and both databases present
- `python -m alembic upgrade head` and `python -m alembic current` against the Compose development DB
- `python -m pytest` against the fresh Compose test DB: 11 passed
- teardown via `docker compose --project-name keylornet-fnd006-validation down --volumes`

Closes #15