### PR TITLE
ci(database): validate PostgreSQL migrations

### DIFF
--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -1,0 +1,68 @@
+name: Database Migration CI
+
+on:
+  pull_request:
+    paths:
+      - "database/**"
+      - ".github/workflows/database-migration.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "database/**"
+      - ".github/workflows/database-migration.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  migration-validation:
+    name: Database migration validation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: database
+    services:
+      postgres:
+        image: postgres:17.11
+        env:
+          POSTGRES_DB: keylornet_test
+          POSTGRES_USER: keylornet
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U keylornet -d keylornet_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      KEYLORNET_TEST_DATABASE_URL: postgresql+psycopg://keylornet:postgres@localhost:5432/keylornet_test
+      KEYLORNET_DATABASE_URL: postgresql+psycopg://keylornet:postgres@localhost:5432/keylornet_test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install constrained database dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -c constraints.txt -e '.[dev]'
+          python -m pip check
+
+      - name: Run database test suite
+        run: python -m pytest --junitxml=pytest-report.xml
+
+      - name: Verify migration integration test executed
+        run: >-
+          python -c "import xml.etree.ElementTree as etree; root = etree.parse('pytest-report.xml').getroot(); cases = [case for case in root.iter('testcase') if case.get('name') == 'test_upgrade_clean_database_records_head']; assert len(cases) == 1, f'expected one migration test, found {len(cases)}'; assert cases[0].find('skipped') is None, 'migration integration test was skipped'"
+
+      - name: Verify Alembic current head
+        run: |
+          python -m alembic current | tee alembic-current.txt
+          grep -Eq '^20260828_0001 \(head\)$' alembic-current.txt
+          python -m alembic heads

--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -2,15 +2,11 @@ name: Database Migration CI
 
 on:
   pull_request:
-    paths:
-      - "database/**"
-      - ".github/workflows/database-migration.yml"
+    branches:
+      - main
   push:
     branches:
       - main
-    paths:
-      - "database/**"
-      - ".github/workflows/database-migration.yml"
 
 permissions:
   contents: read

--- a/database/README.md
+++ b/database/README.md
@@ -45,6 +45,10 @@ python -m pip freeze --exclude-editable | Sort-Object | Set-Content constraints.
 
 Commit `pyproject.toml` and `constraints.txt` together.
 
+The stable GitHub Actions check for this package is `Database Migration CI /
+Database migration validation`; FND-012 can require this exact check name for
+branch protection.
+
 ## Migration conventions
 
 - Every schema change is a new Alembic revision in migrations/versions; do not


### PR DESCRIPTION
## Summary

Closes #18.

Adds deterministic PostgreSQL migration CI for the database package.

## Scope

- PostgreSQL 17.11 ephemeral service with a disposable `keylornet_test` database
- constrained installation via `database/constraints.txt`
- psycopg 3-only test URLs
- full pytest suite plus an explicit JUnit assertion that the migration integration test ran and was not skipped
- Alembic current/head verification
- documented stable branch-protection check: `Database Migration CI / Database migration validation`

## Validation

- YAML parsed locally
- local PostgreSQL 17.11: 11 passed; migration test executed, Alembic current/head `20260828_0001 (head)`

## Security

Uses only `contents: read`; no repository secrets or deployment credentials are required.

## Follow-up

Keep draft until independent QA confirms the real GitHub Actions run.