### PR TITLE
DOC-001 — Add durable project context and product memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,19 @@ This document describes the AI agents configured for the fitness-app project.
 
 ## Source of truth
 
-Before making changes, inspect the relevant documentation under:
+At the start of a fresh session or when project context may be incomplete, read:
+- `docs/project-context/README.md`
+- `docs/project-context/PRODUCT_VISION.md`
+- `docs/project-context/TECHNICAL_BLUEPRINT.md`
+- `docs/project-context/PROJECT_STATE.md`
+
+Then inspect the relevant authoritative documentation under:
 - docs/architecture/
 - docs/design-docs/
 - docs/product-specs/
 - docs/exec-plans/
+
+The project-context pack is a rehydration layer, not a replacement for accepted ADRs or current implementation contracts. Follow the source-of-truth precedence documented in `docs/project-context/README.md`.
 
 Do not invent architecture when an existing decision exists.
 

--- a/docs/project-context/PRODUCT_VISION.md
+++ b/docs/project-context/PRODUCT_VISION.md
@@ -1,0 +1,229 @@
+# Keylornet product vision
+
+## Product in one sentence
+
+Keylornet is a mobile-first gym training product where users can reliably record workouts, understand their progress, compare meaningful performance with groups, and optionally share training-related social content.
+
+The product is not intended to be a generic social network with a workout form attached. The training record is the core domain and source of value; competition, analytics and social features are built on top of trustworthy workout data.
+
+## Core user jobs
+
+A user should be able to:
+
+- register and sign in;
+- start and complete a gym session;
+- add exercises and record sets, repetitions, load and comments;
+- support non-standard set measurements such as duration, distance, RPE/RIR or assisted/bodyweight work when needed;
+- review workout history and progression;
+- identify personal records and trends;
+- browse a curated exercise catalogue by muscle, equipment/machine and category, with useful execution guidance;
+- create or join groups;
+- compare attendance, consistency, volume and exercise strength with other members of a group;
+- eventually see a defensible muscle-level performance score rather than a naive sum of machine kilograms;
+- optionally share a workout, text or photographs as a social post;
+- keep workouts private even when the social layer exists.
+
+## Product principles to preserve
+
+### 1. Workout data is the source of truth
+
+Raw workout sessions, exercises and sets are authoritative. Rankings, records, streaks, volume and other statistics are derived and must be reproducible from source workout data.
+
+Do not make a derived ranking table the only source of historical truth.
+
+### 2. Recording a set must work without connectivity
+
+A gym is exactly the kind of environment where coverage can be poor. The user experience must not depend on a round-trip to the server for every set.
+
+The intended flow is:
+
+`user input -> local persistent state -> immediate UI update -> sync queue -> API when network is available -> PostgreSQL`
+
+Offline-first behavior is therefore a product requirement, not merely a later performance optimization.
+
+### 3. Exercise comparability matters
+
+`Bench press - barbell`, `bench press - dumbbell`, `Smith-machine press` and a plate-loaded chest press are not interchangeable measurements for ranking purposes.
+
+Exercise identity and variant/equipment must be modeled carefully enough that comparisons remain interpretable.
+
+### 4. Rankings should be meaningful, not gimmicky
+
+Attendance and session-count rankings are straightforward. Strength comparisons require compatible exercises/variants. Muscle-level rankings must not simply add displayed kilograms across unrelated machines.
+
+The product should prefer transparent methodology that a user can inspect over an opaque score with no explanation.
+
+### 5. Group competition before global competition
+
+Groups are a first-class domain concept. The initial competitive experience is among friends, gym partners or other explicit groups rather than a single global leaderboard.
+
+Expected group roles are `OWNER`, `ADMIN` and `MEMBER`.
+
+### 6. Workout and social post are different entities
+
+A workout can exist privately with no post. A post may optionally reference a workout. This separation prevents the social layer from contaminating the training record and supports privacy cleanly.
+
+### 7. Privacy is explicit
+
+The design intent includes `PRIVATE`, `GROUP` and `PUBLIC` visibility where relevant. Photos and social features must not force workout data to become public.
+
+## Core domain model
+
+The intended conceptual entities include:
+
+- users / profiles
+- groups / group_members
+- muscles
+- equipment
+- exercise_categories
+- exercises
+- exercise_muscles
+- exercise instructions/media
+- workout_sessions
+- workout_exercises
+- workout_sets
+- personal records / derived statistics
+- posts / post_media / comments / reactions
+- notifications / device tokens
+
+A workout should be normalized into session -> exercises -> sets rather than stored as one opaque JSON object.
+
+### Workout set flexibility
+
+The initial dominant case is weight + repetitions, but the model should not make that the only possible exercise measurement. Depending on exercise type, a set may eventually contain optional fields such as:
+
+- `weight_kg`
+- `repetitions`
+- `duration_seconds`
+- `distance_m`
+- `rpe`
+- `rir`
+- `set_type`
+- `completed`
+
+This protects the product from later schema redesign for running, cycling, planks, isometrics, pull-ups and assisted exercises.
+
+## Exercise catalogue intent
+
+The app should have its own internal exercise catalogue. A source such as wger may be useful for bootstrapping data, but Keylornet must not depend on an external exercise API at runtime.
+
+The intended ingestion model is:
+
+`external/open source -> importer -> normalization -> Keylornet database -> curation`
+
+Licensing for descriptions and media must be checked independently before redistribution.
+
+The system should eventually support both curated/system exercises and user-created custom exercises, so a user can represent a specific machine at their gym without polluting the canonical catalogue.
+
+## Rankings and analytics intent
+
+### Attendance / consistency
+
+Useful periods include week, month, year and all-time. A completed session is the basic unit. Anti-gaming rules may be introduced so meaningless empty sessions do not count as visits.
+
+### Exercise strength
+
+A preferred strength comparison is estimated 1RM rather than only maximum displayed load. Epley is the current design candidate:
+
+`e1RM = weight * (1 + repetitions / 30)`
+
+This formula is **provisional methodology**, not an immutable contract. The key product requirement is compatible, understandable exercise-level comparison.
+
+Useful exercise statistics include best load, repetitions, volume and e1RM.
+
+### Volume
+
+Basic loaded-set volume is:
+
+`volume = sum(weight * repetitions)`
+
+Useful slices include weekly/monthly totals and exercise/muscle views, subject to sensible rules for exercises where load x reps is not meaningful.
+
+### Muscle strength score
+
+Do **not** rank a muscle by summing raw kilograms from heterogeneous exercises/machines.
+
+The current design direction is:
+
+1. compute a user's performance percentile for each comparable exercise/variant within the relevant population/group;
+2. associate exercises to muscles with roles/contribution weights (`PRIMARY`, `SECONDARY`, potentially `STABILIZER`);
+3. aggregate normalized exercise performance into an explainable muscle score.
+
+This remains a design direction to formalize before implementation. The user must be able to inspect which exercises contribute to a muscle score.
+
+## Social intent
+
+Social is deliberately later than the workout engine. Expected capabilities eventually include:
+
+- text posts;
+- optional link to a completed workout;
+- workout summary cards;
+- photos;
+- reactions/likes;
+- comments;
+- group/public/private visibility.
+
+The social layer should strengthen training engagement rather than dictate the data model of workouts.
+
+## Privacy, trust and safety intent
+
+From the first socially enabled version, the product should account for:
+
+- account deletion;
+- user data export;
+- block/report flows;
+- deletion of posts;
+- group privacy;
+- server-side validation;
+- media size/type constraints;
+- stripping unnecessary photo EXIF, especially location metadata;
+- rate limiting;
+- secrets kept server-side;
+- auditability for sensitive operations;
+- backups and recovery.
+
+Avoiding accounts for minors initially is the preferred product direction because it materially reduces moderation and regulatory complexity.
+
+## Delivery phases
+
+The intended product sequence is:
+
+### Foundation
+
+Repository, API/mobile/database foundations, local development, CI, test architecture, protected main and a real mobile-to-API health path.
+
+### Identity
+
+Registration/login, profile and authorization foundation.
+
+### Exercise catalogue
+
+Canonical exercise taxonomy, muscles/equipment, instructions and catalogue access.
+
+### Workout engine
+
+Create/continue/complete sessions; add exercises; log sets; comments; resilient local recording.
+
+### History and analytics
+
+Workout history, progress, personal records, volume and derived statistics.
+
+### Groups and rankings
+
+Groups, membership/roles, attendance and exercise rankings, then defensible muscle-level scores.
+
+### Robust offline sync
+
+Conflict behavior, retry/idempotency and mature offline workflows beyond the basic foundation.
+
+### Social
+
+Posts, media, comments/reactions, workout sharing and privacy/moderation flows.
+
+### Beta / advanced product
+
+Notifications, templates/routines, rest timers, advanced charts/goals, integrations such as Apple Health / Health Connect / Garmin, and later recommendation/ML possibilities.
+
+## Explicit non-goal
+
+Do not try to build Instagram + Strava + Hevy + Strong simultaneously. The architecture should permit the larger product, but implementation should preserve the ordering above so the workout core becomes trustworthy before higher-level features depend on it.

--- a/docs/project-context/PROJECT_STATE.md
+++ b/docs/project-context/PROJECT_STATE.md
@@ -1,0 +1,134 @@
+# Keylornet project state
+
+Last updated: 2026-08-28
+
+This is the fast handoff for resuming work. It is intentionally operational and may become stale if not updated after merges; GitHub issues, PRs and `main` are the final authority for real-time status.
+
+## Current milestone
+
+**M0 — Foundation**
+
+Goal: establish a reproducible professional baseline before implementing identity or product-domain features.
+
+M0 gate includes:
+
+- backend skeleton
+- mobile skeleton
+- PostgreSQL/Alembic baseline
+- reproducible local Docker/PostgreSQL environment
+- backend CI
+- mobile CI
+- database migration CI
+- real mobile-to-API health path
+- coherent test architecture
+- protected `main` using real CI checks
+- independent QA/review gates
+
+## Merged foundation work
+
+- FND-003 FastAPI skeleton — merged
+- FND-004 Expo/React Native mobile skeleton — merged
+- FND-005 PostgreSQL/Alembic baseline — merged
+- FND-007 Backend CI — merged
+
+Current `main` at the time of this update includes FND-007.
+
+## Open M0 work
+
+### FND-006 — Local Docker environment
+
+- Issue: #15
+- PR: #20
+- Branch: `codex/fnd-006-local-docker`
+- State: draft, mergeable
+- Implementation validation reported: Compose config, fresh PostgreSQL health, dev/test databases, Alembic upgrade/current and 11 database tests
+- Remaining gate: independent QA completion before merge
+
+### FND-008 — Mobile CI
+
+- Issue: #17
+- PR: #22
+- Branch: `codex/fnd-008-mobile-ci`
+- State: draft, mergeable
+- Real GitHub Actions `Mobile CI / mobile-quality`: PASS
+- Local clean install, format, lint, TypeScript and Jest validation: PASS
+- Important repair included: the FND-004 lock/dependency baseline was not reproducible with `npm ci`; dependency versions/lockfile were repaired and Jest types added to TypeScript configuration
+- Workflow was corrected to run the required mobile check for every PR targeting `main`, avoiding future branch-protection deadlocks caused by path-filtered required checks
+- Remaining gate: independent `qa_engineer` verification, then Ready/merge
+
+### FND-009 — Database migration CI
+
+- Issue: #18
+- PR: #21
+- Branch: `codex/fnd-009-database-ci`
+- State: draft, mergeable
+- Real GitHub Actions migration workflow previously observed green
+- Validates PostgreSQL service, constrained install, real migration integration test and Alembic current/head
+- Remaining gate: independent QA
+- Follow-up before FND-012: review/remove path filtering if this check is to become required on all PRs
+
+## Next M0 work after current parallel wave
+
+### FND-010 — Mobile -> API health path
+
+Depends on the API/mobile foundations and usable local environment. Implement a real end-to-end development path where the mobile client can reach a FastAPI health endpoint with environment-safe configuration.
+
+### FND-011 — Test architecture
+
+Consolidate how unit/integration/domain tests are organized across API, mobile and database layers and ensure foundation tests reflect intended boundaries.
+
+### FND-012 — Protect `main`
+
+Depends on real backend/mobile/database CI checks and their exact GitHub check names.
+
+Before enabling protection, ensure every check selected as required is guaranteed to report on every protected PR. Do not configure a path-filtered workflow as a globally required status check unless an always-reporting gating design is used.
+
+Known corrective work: merged Backend CI currently uses path filters and needs adjustment before it is made globally required. Database CI should be corrected before merge or in a focused follow-up. Mobile CI has already been corrected on PR #22.
+
+## Current CI names
+
+Observed/intended deterministic contexts:
+
+- Backend: `Backend CI / Backend CI`
+- Mobile: `Mobile CI / mobile-quality`
+- Database: `Database Migration CI / Database migration validation`
+
+Verify exact GitHub check contexts again immediately before FND-012 rather than trusting this document.
+
+## Roadmap after M0
+
+The current roadmap is:
+
+- M1 Identity
+- M2 Exercise Catalog
+- M3 Workout Engine
+- M4 History / Analytics
+- M5 Groups / Rankings
+- M6 Robust Offline Sync
+- M7 Social
+- M8 Beta / advanced product
+
+Do not reorder later features in a way that makes social/rankings depend on untrustworthy workout data.
+
+## Engineering operating model
+
+- Product Owner: user
+- Main ChatGPT/Codex thread: orchestrator and final synthesis
+- `project_manager`: backlog/dependencies/planning
+- `tech_lead`: architecture, ADRs, contracts, high-risk review
+- `backend_engineer`: `services/api/`
+- `mobile_engineer`: `apps/mobile/`
+- `data_engineer`: database/migrations/analytics/rankings; structural migration owner
+- `qa_engineer`: independent verification
+- `devops_engineer`: Docker/infra/GitHub Actions
+- `security_engineer`: auth/privacy/security review
+
+One focused issue should normally map to one branch and PR. Use isolated worktrees for parallel write-heavy tasks. Implementation agents do not self-approve; QA and architectural/security gates remain independent.
+
+## Definition of Done reminder
+
+A task is not done only because code exists or local commands pass. It should satisfy acceptance criteria, relevant tests, format/lint/type checks, documentation, focused diff, required architecture/security review, independent QA and real CI where applicable.
+
+## Active documentation continuity task
+
+DOC-001 / issue #23 introduces `docs/project-context/` so future sessions can recover the product and technical intent without relying on chat memory. Once merged, future agents should read this directory before planning or changing architecture.

--- a/docs/project-context/README.md
+++ b/docs/project-context/README.md
@@ -1,0 +1,51 @@
+# Keylornet project context
+
+This directory is the durable handoff for product and engineering context that would otherwise live only in long chat histories.
+
+It is intentionally concise enough to read at the start of a new ChatGPT/Codex session, but detailed enough to recover the original product intent and the rationale behind the architecture.
+
+## Read this first
+
+A fresh engineer or agent should read, in this order:
+
+1. `docs/project-context/PRODUCT_VISION.md`
+2. `docs/project-context/TECHNICAL_BLUEPRINT.md`
+3. `docs/project-context/PROJECT_STATE.md`
+4. relevant files under `docs/product-specs/`
+5. relevant ADRs under `docs/architecture/adr/`
+6. the current implementation issue / PR / execution plan
+
+## Source-of-truth precedence
+
+This context pack is a rehydration and intent document. It does **not** override more specific accepted decisions.
+
+When sources disagree, use this precedence:
+
+1. accepted ADR for an architectural decision
+2. approved/current design document or implementation contract
+3. current product specification / acceptance criteria
+4. this project-context pack
+5. historical chat or exploratory notes
+
+If a product requirement itself changes, update the appropriate product spec and this context pack. If architecture changes, record or supersede the relevant ADR.
+
+## Status vocabulary
+
+The documents distinguish between:
+
+- **Accepted**: already adopted by ADR, merged foundation, or explicit project decision.
+- **Product intent**: behavior we deliberately want to preserve while implementation evolves.
+- **Provisional**: a strong default/design candidate that still needs a dedicated implementation decision or validation.
+- **Future**: explicitly deferred beyond the current milestone/MVP.
+
+Do not silently promote a provisional idea into an irreversible contract.
+
+## Maintenance rule
+
+`PROJECT_STATE.md` is a living handoff and should be updated after meaningful merges, roadmap changes, dependency changes, or newly discovered blockers.
+
+`PRODUCT_VISION.md` and `TECHNICAL_BLUEPRINT.md` should change much less frequently: only when the actual product intent or architecture meaningfully changes.
+
+## Why this exists
+
+Keylornet was designed through a long product/architecture discussion covering workout logging, exercise taxonomy, rankings, groups, social features, privacy, offline behavior, analytics, infrastructure and delivery strategy. The important ideas must survive model/session changes and should not depend on anyone remembering a previous conversation.

--- a/docs/project-context/TECHNICAL_BLUEPRINT.md
+++ b/docs/project-context/TECHNICAL_BLUEPRINT.md
@@ -1,0 +1,208 @@
+# Keylornet technical blueprint
+
+This document summarizes the technical direction and rationale established during the original design work. Accepted ADRs remain authoritative where they exist.
+
+## Architectural shape
+
+**Accepted:** start as a modular monolith, not microservices.
+
+Primary flow:
+
+`React Native / Expo -> FastAPI -> PostgreSQL`
+
+Supporting managed infrastructure:
+
+- Supabase PostgreSQL
+- Supabase Auth
+- Supabase Storage
+- Expo Notifications
+
+This deliberately avoids premature Kubernetes, Kafka, Redis and service decomposition. The separation between mobile, API and PostgreSQL keeps a path open for a future web client, external integrations and infrastructure migration without coupling the mobile app directly to database implementation details.
+
+See `docs/architecture/adr/ADR-001-modular-monolith.md`.
+
+## Mobile
+
+Chosen stack/direction:
+
+- React Native
+- Expo
+- TypeScript
+- Expo Router
+- TanStack Query for server state
+- Zustand for appropriate local UI/app state
+- React Hook Form + Zod for forms/validation where useful
+- Expo SQLite for persistent offline data
+- Expo ImagePicker for media selection
+- Expo Notifications for push notifications
+
+### Offline-first invariant
+
+**Accepted:** workout recording must be local-first. See ADR-003.
+
+Client-generated identifiers, local persistence and explicit sync state should be used so a set can be captured without server connectivity. Mature synchronization should include retry behavior and idempotency; conflict rules are to be specified when the workout/sync domain is implemented.
+
+The server remains authoritative after successful synchronization; offline-first does not mean duplicating business/ranking authority in the mobile client.
+
+## Backend
+
+Chosen stack:
+
+- Python
+- FastAPI
+- Pydantic
+- SQLAlchemy 2
+- Alembic
+- pytest
+
+The backend is organized by domain modules rather than deployed services. Expected long-term modules include auth/users, exercises, workouts, analytics, groups, rankings, social, media and notifications.
+
+Preferred internal flow:
+
+`HTTP router -> service/domain logic -> repository/data access -> PostgreSQL`
+
+Authoritative business rules, authorization and ranking methodology belong server-side.
+
+## API contract
+
+REST/OpenAPI is the baseline. FastAPI's OpenAPI document should become the contract used to generate a typed TypeScript client rather than manually maintaining duplicate request/response definitions in Python and TypeScript.
+
+The generated client is a future implementation milestone; do not hand-build parallel contracts when generation becomes available.
+
+## Database
+
+**Accepted:** PostgreSQL with Alembic migrations.
+
+PostgreSQL is preferred because the product is highly relational and analytics-heavy: users, sessions, sets, exercises, muscles, groups, rankings, records and social relationships need joins, constraints and reproducible aggregation.
+
+Core conceptual model:
+
+- `users`, `profiles`
+- `groups`, `group_members`
+- `muscles`, `equipment`, `exercise_categories`
+- `exercises`, `exercise_muscles`, exercise instruction/media data
+- `workout_sessions`, `workout_exercises`, `workout_sets`
+- personal records / derived statistics
+- `posts`, `post_media`, `comments`, `reactions`
+- notifications / device tokens
+
+Exact schemas, constraints and indexes must be introduced through migrations and dedicated design/implementation work; this blueprint does not substitute for migration review.
+
+## Exercise-muscle model
+
+Design intent is many-to-many. An exercise may contribute to several muscles with semantic roles such as `PRIMARY`, `SECONDARY`, and potentially `STABILIZER`.
+
+A numeric contribution may eventually support normalized muscle analytics, but weights such as 1.0 / 0.5 / 0.2 are provisional examples, not committed scientific constants.
+
+Exercise identity should preserve variant/equipment differences sufficiently for fair comparisons.
+
+## Derived statistics
+
+Raw workout data is authoritative:
+
+`workout source data -> reproducible derived statistics`
+
+For performance, derived tables/materialized calculations may later include concepts such as:
+
+- per-user/per-exercise best weight/e1RM/volume/last performed
+- activity counts by week/month/year
+- cached group ranking outputs
+
+These are accelerators, never substitutes for raw history.
+
+## Ranking methodology guardrails
+
+- Attendance: count qualifying completed sessions in a period; anti-gaming qualification can be added.
+- Exercise strength: compare compatible exercise variants; estimated 1RM is preferred over naive max weight for rep-based strength comparison.
+- Volume: `sum(weight * reps)` where that metric is meaningful.
+- Muscle score: never sum raw kilograms across heterogeneous machines. Normalize comparable exercise performance first, then aggregate with explainable muscle contribution weights.
+
+The exact formulas and eligibility rules should be versioned as business rules/tests when rankings are implemented.
+
+## Authentication and authorization
+
+**Accepted direction:** Supabase Auth provides identity; FastAPI validates identity/token information and applies application authorization. See ADR-002.
+
+Never place privileged Supabase/service credentials in the mobile app.
+
+Where Supabase Data API access is used directly, exposed tables must be protected appropriately (for example via RLS). Prefer clear server-side authorization boundaries for application business operations.
+
+## Media
+
+Binary images belong in object storage, not PostgreSQL. Database rows store metadata/object keys and relationships.
+
+Media handling should include:
+
+- allowed MIME/type checks
+- size/dimension constraints
+- ownership/authorization
+- removal of unnecessary EXIF/location metadata before publishing
+- safe deletion lifecycle
+
+## Security and GDPR baseline
+
+Architecture must leave room for and eventually implement:
+
+- account deletion
+- data export
+- explicit privacy/visibility
+- user blocking and content reporting
+- server-side validation
+- rate limiting
+- privileged secrets only server-side
+- audit trails for sensitive operations
+- backups/recovery
+- media constraints and EXIF hygiene
+
+Security should not be postponed until after social features are built.
+
+## Infrastructure
+
+Deployment direction:
+
+- Dockerized FastAPI
+- GitHub repository and GitHub Actions CI
+- PostgreSQL/Supabase managed database
+- Supabase Auth and Storage
+- Cloudflare DNS when public deployment is introduced
+
+The API may eventually use `api.fit.jonathansalgadonieto.com`; a project/web/admin surface may later use related subdomains. The existing personal website should remain independent.
+
+Containerization should keep the API portable across reasonable hosting providers rather than binding core architecture to one vendor.
+
+## Repository shape
+
+Monorepo is intentional. Current/target top-level areas include:
+
+- `apps/mobile/`
+- `services/api/`
+- `database/`
+- `packages/` (for example a generated API client later)
+- `infra/`
+- `.github/`
+- `docs/`
+
+## Testing and delivery principles
+
+Foundation quality gates should include:
+
+- backend formatting/lint/type/tests
+- mobile formatting/lint/type/tests
+- real PostgreSQL migration/integration validation
+- reproducible local Docker environment
+- branch protection using real, deterministic CI check names
+
+Later layers add domain integration tests and mobile E2E/device tests where they provide value.
+
+## Decision hygiene
+
+If implementation needs to change one of these architectural fundamentals, do not silently drift the code. Raise the decision, update/supersede the relevant ADR, then update this blueprint.
+
+Examples that require architectural review include:
+
+- replacing the modular monolith with services
+- changing auth authority/boundaries
+- abandoning offline-first workout recording
+- bypassing FastAPI as the business-rule layer
+- changing the primary database technology
+- making mobile authoritative for ranking calculations


### PR DESCRIPTION
## Summary

- add a durable `docs/project-context/` rehydration pack for future ChatGPT/Codex sessions and engineers
- preserve the original product vision, domain intent, ranking methodology guardrails, offline-first requirement, privacy/social boundaries and phased roadmap
- preserve the technical blueprint and rationale without overriding accepted ADRs
- add a living M0 project-state handoff with current PRs, CI names, next dependencies and known branch-protection follow-ups
- update root `AGENTS.md` so fresh agents read project context before planning or making changes

## Source-of-truth design

The context pack explicitly defines precedence: accepted ADRs and current implementation contracts remain authoritative. Historical product intent is preserved without silently turning provisional formulas or future ideas into immutable architecture.

## Why

The project now spans long design conversations plus multiple parallel foundation PRs. This prevents continuity from depending on chat/model memory.

Closes #23