### PR TITLE
ci(api): make backend CI branch-protection safe

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,15 +2,9 @@ name: Backend CI
 
 on:
   pull_request:
-    paths:
-      - "services/api/**"
-      - ".github/workflows/backend-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "services/api/**"
-      - ".github/workflows/backend-ci.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Makes the existing backend CI required context safe for future global branch protection.

Closes #25.

## Changes

- Removes the PR and push path filters from Backend CI.
- Preserves the workflow and job names that produce `Backend CI / Backend CI`.
- Preserves constrained installation, format, Ruff, mypy, pytest, and `contents: read` permissions.

## Validation

- YAML and `git diff --check` passed locally.
- GitHub Actions validation is pending on this final PR head.

## Risks and assumptions

The workflow now runs on every pull request targeting `main`, including unrelated changes, intentionally ensuring the required context is present for FND-012. No backend behavior or dependency strategy changed.

## Rollback

Revert commit `4fc9186` to restore the previous path-filtered workflow.