### PR TITLE
feat(mobile): add API health integration

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,2 +1,3 @@
-# Development-only base URL. Use a reachable host for a physical device.
+# Development-only base URL for the iOS simulator. See README.md for Android
+# emulator and physical-device LAN addresses.
 EXPO_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -16,11 +16,30 @@ cp .env.example .env
 npm install
 ```
 
-`EXPO_PUBLIC_API_BASE_URL` is optional during this foundation stage. When it is
-set, it must be an `http` or `https` URL and must point to a development or test
-environment; do not commit a `.env` file or production credentials. For a
-physical device, `localhost` refers to the device, so use a reachable local
-network host instead.
+`EXPO_PUBLIC_API_BASE_URL` is required for the development health check. It
+must be an `http` or `https` URL that points to a development or test
+environment. Do not commit a `.env` file, production endpoint, or credentials:
+all `EXPO_PUBLIC_` values are visible in the client bundle.
+
+### Connecting to the local API
+
+Start the API from `services/api/`:
+
+```sh
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Then set the base URL appropriate for the client running the app:
+
+- iOS Simulator on the development machine: `http://localhost:8000`
+- Android Emulator:
+  `http://10.0.2.2:8000`
+- Physical device running Expo Go: `http://<development-machine-LAN-IP>:8000`
+
+For a physical device, `localhost` means the phone itself, not the development
+machine. Keep the device and development machine on the same trusted LAN, allow
+the local port through the host firewall when necessary, and restart Expo after
+changing `.env`.
 
 ## Development
 
@@ -31,9 +50,10 @@ npm run ios
 npm run web
 ```
 
-The root route only reports foundation status and the configured API base URL.
-It does not call an API yet. Future health integration is tracked separately as
-FND-010, once the server contract and local environment are available.
+The root route calls `GET /health` through the shared API abstraction. It shows
+loading, healthy, or readable error status without crashing if the server is
+unreachable or its response is invalid. The stable accepted backend response is
+`200 {"status":"ok"}`.
 
 ## Validation
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -52,8 +52,10 @@ npm run web
 
 The root route calls `GET /health` through the shared API abstraction. It shows
 loading, healthy, or readable error status without crashing if the server is
-unreachable or its response is invalid. The stable accepted backend response is
-`200 {"status":"ok"}`.
+unreachable or its response is invalid. The health request is cancelled after
+five seconds so an unreachable LAN endpoint shows `Health request timed out.`
+instead of leaving the screen loading indefinitely. The stable accepted backend
+response is `200 {"status":"ok"}`.
 
 ## Validation
 

--- a/apps/mobile/components/__tests__/development-status.test.tsx
+++ b/apps/mobile/components/__tests__/development-status.test.tsx
@@ -39,4 +39,39 @@ describe('DevelopmentStatus', () => {
       ).toBeTruthy();
     });
   });
+
+  it('shows the health timeout message instead of loading indefinitely', async () => {
+    const { getByText } = await render(
+      <DevelopmentStatus
+        loadHealth={async () => {
+          throw new Error('Health request timed out.');
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText('API health check failed: Health request timed out.'),
+      ).toBeTruthy();
+    });
+  });
+
+  it('cancels an in-flight health check when the component unmounts', async () => {
+    let requestSignal: AbortSignal | undefined;
+    const loadHealth = jest.fn(({ signal }: { signal?: AbortSignal } = {}) => {
+      requestSignal = signal;
+      return new Promise<never>(() => undefined);
+    });
+
+    const { unmount } = await render(
+      <DevelopmentStatus loadHealth={loadHealth} />,
+    );
+
+    await waitFor(() => {
+      expect(loadHealth).toHaveBeenCalled();
+    });
+    await unmount();
+
+    expect(requestSignal?.aborted).toBe(true);
+  });
 });

--- a/apps/mobile/components/__tests__/development-status.test.tsx
+++ b/apps/mobile/components/__tests__/development-status.test.tsx
@@ -1,12 +1,42 @@
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 
 import { DevelopmentStatus } from '../development-status';
 
 describe('DevelopmentStatus', () => {
-  it('shows the mobile foundation status', async () => {
-    const { getByText } = await render(<DevelopmentStatus />);
+  it('shows a loading API state while the health check is pending', async () => {
+    const { getByText, unmount } = await render(
+      <DevelopmentStatus loadHealth={() => new Promise(() => undefined)} />,
+    );
+
+    expect(getByText('Checking API health…')).toBeTruthy();
+    await unmount();
+  });
+
+  it('shows a healthy API state', async () => {
+    const { getByText } = await render(
+      <DevelopmentStatus loadHealth={async () => ({ status: 'ok' })} />,
+    );
 
     expect(getByText('Keylornet mobile')).toBeTruthy();
-    expect(getByText('Development foundation is ready.')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(getByText('API is healthy.')).toBeTruthy();
+    });
+  });
+
+  it('shows a readable error when the API cannot be reached', async () => {
+    const { getByText } = await render(
+      <DevelopmentStatus
+        loadHealth={async () => {
+          throw new Error('Network request failed');
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText('API health check failed: Network request failed'),
+      ).toBeTruthy();
+    });
   });
 });

--- a/apps/mobile/components/development-status.tsx
+++ b/apps/mobile/components/development-status.tsx
@@ -1,16 +1,91 @@
+import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { getApiBaseUrl } from '@/lib/api/client';
+import { getHealth, type HealthResponse } from '@/lib/api/health';
 
-export function DevelopmentStatus() {
-  const apiBaseUrl = getApiBaseUrl();
+type HealthState =
+  | { kind: 'loading' }
+  | { kind: 'healthy' }
+  | { kind: 'error'; message: string };
+
+type DevelopmentStatusProps = {
+  loadHealth?: () => Promise<HealthResponse>;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unable to reach the API.';
+}
+
+function readApiConfiguration(): {
+  apiBaseUrl?: string;
+  error?: string;
+} {
+  try {
+    return { apiBaseUrl: getApiBaseUrl() };
+  } catch (error) {
+    return { error: errorMessage(error) };
+  }
+}
+
+export function DevelopmentStatus({
+  loadHealth = getHealth,
+}: DevelopmentStatusProps) {
+  const [healthState, setHealthState] = useState<HealthState>({
+    kind: 'loading',
+  });
+  const apiConfiguration = readApiConfiguration();
+
+  useEffect(() => {
+    let active = true;
+
+    if (apiConfiguration.error) {
+      return () => {
+        active = false;
+      };
+    }
+
+    void loadHealth()
+      .then(() => {
+        if (active) {
+          setHealthState({ kind: 'healthy' });
+        }
+      })
+      .catch((error: unknown) => {
+        if (active) {
+          setHealthState({ kind: 'error', message: errorMessage(error) });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [apiConfiguration.error, loadHealth]);
+
+  const visibleHealthState: HealthState = apiConfiguration.error
+    ? { kind: 'error', message: apiConfiguration.error }
+    : healthState;
 
   return (
     <View style={styles.container} accessibilityRole="summary">
       <Text style={styles.heading}>Keylornet mobile</Text>
-      <Text style={styles.message}>Development foundation is ready.</Text>
+      {visibleHealthState.kind === 'loading' ? (
+        <Text accessibilityLiveRegion="polite" style={styles.message}>
+          Checking API health…
+        </Text>
+      ) : null}
+      {visibleHealthState.kind === 'healthy' ? (
+        <Text accessibilityLiveRegion="polite" style={styles.message}>
+          API is healthy.
+        </Text>
+      ) : null}
+      {visibleHealthState.kind === 'error' ? (
+        <Text accessibilityLiveRegion="polite" style={styles.error}>
+          API health check failed: {visibleHealthState.message}
+        </Text>
+      ) : null}
       <Text style={styles.endpoint} selectable>
-        API base URL: {apiBaseUrl ?? 'Not configured'}
+        API base URL: {apiConfiguration.apiBaseUrl ?? 'Not configured'}
       </Text>
     </View>
   );
@@ -31,6 +106,12 @@ const styles = StyleSheet.create({
   message: {
     fontSize: 16,
     marginBottom: 8,
+  },
+  error: {
+    color: '#b00020',
+    fontSize: 16,
+    marginBottom: 8,
+    textAlign: 'center',
   },
   endpoint: {
     fontSize: 14,

--- a/apps/mobile/components/development-status.tsx
+++ b/apps/mobile/components/development-status.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { getApiBaseUrl } from '@/lib/api/client';
-import { getHealth, type HealthResponse } from '@/lib/api/health';
+import {
+  getHealth,
+  type HealthRequestOptions,
+  type HealthResponse,
+} from '@/lib/api/health';
 
 type HealthState =
   | { kind: 'loading' }
@@ -10,7 +14,7 @@ type HealthState =
   | { kind: 'error'; message: string };
 
 type DevelopmentStatusProps = {
-  loadHealth?: () => Promise<HealthResponse>;
+  loadHealth?: (options?: HealthRequestOptions) => Promise<HealthResponse>;
 };
 
 function errorMessage(error: unknown): string {
@@ -38,14 +42,16 @@ export function DevelopmentStatus({
 
   useEffect(() => {
     let active = true;
+    const controller = new AbortController();
 
     if (apiConfiguration.error) {
       return () => {
         active = false;
+        controller.abort();
       };
     }
 
-    void loadHealth()
+    void loadHealth({ signal: controller.signal })
       .then(() => {
         if (active) {
           setHealthState({ kind: 'healthy' });
@@ -59,6 +65,7 @@ export function DevelopmentStatus({
 
     return () => {
       active = false;
+      controller.abort();
     };
   }, [apiConfiguration.error, loadHealth]);
 

--- a/apps/mobile/lib/api/__tests__/health.test.ts
+++ b/apps/mobile/lib/api/__tests__/health.test.ts
@@ -1,5 +1,5 @@
 import { requestApi } from '../client';
-import { getHealth } from '../health';
+import { getHealth, HEALTH_REQUEST_TIMEOUT_MS } from '../health';
 
 jest.mock('../client', () => ({
   requestApi: jest.fn(),
@@ -10,6 +10,10 @@ describe('health API client', () => {
     jest.mocked(requestApi).mockReset();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('uses the shared request abstraction for the stable health contract', async () => {
     jest.mocked(requestApi).mockResolvedValue({
       json: async () => ({ status: 'ok' }),
@@ -18,7 +22,9 @@ describe('health API client', () => {
     } as Response);
 
     await expect(getHealth()).resolves.toEqual({ status: 'ok' });
-    expect(requestApi).toHaveBeenCalledWith('/health');
+    expect(requestApi).toHaveBeenCalledWith('/health', {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it('rejects non-success health responses', async () => {
@@ -43,5 +49,33 @@ describe('health API client', () => {
     await expect(getHealth()).rejects.toThrow(
       'Health response did not match the expected contract.',
     );
+  });
+
+  it('aborts an unreachable request and reports a readable timeout', async () => {
+    jest.useFakeTimers();
+    let requestSignal: AbortSignal | undefined;
+
+    jest.mocked(requestApi).mockImplementation((_path, init) => {
+      requestSignal = init?.signal ?? undefined;
+
+      return new Promise<Response>((_resolve, reject) => {
+        requestSignal?.addEventListener(
+          'abort',
+          () => reject(new Error('The fetch request was aborted.')),
+          { once: true },
+        );
+      });
+    });
+
+    const healthRequest = getHealth();
+    const timeoutExpectation = expect(healthRequest).rejects.toThrow(
+      'Health request timed out.',
+    );
+
+    await jest.advanceTimersByTimeAsync(HEALTH_REQUEST_TIMEOUT_MS);
+
+    expect(requestSignal?.aborted).toBe(true);
+    await timeoutExpectation;
+    expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/apps/mobile/lib/api/__tests__/health.test.ts
+++ b/apps/mobile/lib/api/__tests__/health.test.ts
@@ -1,0 +1,47 @@
+import { requestApi } from '../client';
+import { getHealth } from '../health';
+
+jest.mock('../client', () => ({
+  requestApi: jest.fn(),
+}));
+
+describe('health API client', () => {
+  beforeEach(() => {
+    jest.mocked(requestApi).mockReset();
+  });
+
+  it('uses the shared request abstraction for the stable health contract', async () => {
+    jest.mocked(requestApi).mockResolvedValue({
+      json: async () => ({ status: 'ok' }),
+      ok: true,
+      status: 200,
+    } as Response);
+
+    await expect(getHealth()).resolves.toEqual({ status: 'ok' });
+    expect(requestApi).toHaveBeenCalledWith('/health');
+  });
+
+  it('rejects non-success health responses', async () => {
+    jest.mocked(requestApi).mockResolvedValue({
+      json: async () => ({ status: 'error' }),
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(getHealth()).rejects.toThrow(
+      'Health request failed with HTTP 503.',
+    );
+  });
+
+  it('rejects an invalid health payload', async () => {
+    jest.mocked(requestApi).mockResolvedValue({
+      json: async () => ({ status: 'degraded' }),
+      ok: true,
+      status: 200,
+    } as Response);
+
+    await expect(getHealth()).rejects.toThrow(
+      'Health response did not match the expected contract.',
+    );
+  });
+});

--- a/apps/mobile/lib/api/health.ts
+++ b/apps/mobile/lib/api/health.ts
@@ -1,0 +1,29 @@
+import { requestApi } from './client';
+
+export type HealthResponse = {
+  status: 'ok';
+};
+
+/**
+ * Reads the stable development health contract exposed by the FastAPI service.
+ */
+export async function getHealth(): Promise<HealthResponse> {
+  const response = await requestApi('/health');
+
+  if (!response.ok) {
+    throw new Error(`Health request failed with HTTP ${response.status}.`);
+  }
+
+  const payload: unknown = await response.json();
+
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    !('status' in payload) ||
+    payload.status !== 'ok'
+  ) {
+    throw new Error('Health response did not match the expected contract.');
+  }
+
+  return { status: 'ok' };
+}

--- a/apps/mobile/lib/api/health.ts
+++ b/apps/mobile/lib/api/health.ts
@@ -4,26 +4,66 @@ export type HealthResponse = {
   status: 'ok';
 };
 
+export type HealthRequestOptions = {
+  signal?: AbortSignal;
+};
+
+// A development endpoint should not leave the status screen loading forever
+// when a LAN host becomes unreachable. This remains health-specific so future
+// API endpoints can define their own timeout and retry behaviour.
+export const HEALTH_REQUEST_TIMEOUT_MS = 5_000;
+
 /**
  * Reads the stable development health contract exposed by the FastAPI service.
  */
-export async function getHealth(): Promise<HealthResponse> {
-  const response = await requestApi('/health');
+export async function getHealth({
+  signal,
+}: HealthRequestOptions = {}): Promise<HealthResponse> {
+  const controller = new AbortController();
+  let timedOut = false;
 
-  if (!response.ok) {
-    throw new Error(`Health request failed with HTTP ${response.status}.`);
+  const cancelFromCaller = () => {
+    controller.abort();
+  };
+
+  if (signal?.aborted) {
+    cancelFromCaller();
+  } else {
+    signal?.addEventListener('abort', cancelFromCaller, { once: true });
   }
 
-  const payload: unknown = await response.json();
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, HEALTH_REQUEST_TIMEOUT_MS);
 
-  if (
-    typeof payload !== 'object' ||
-    payload === null ||
-    !('status' in payload) ||
-    payload.status !== 'ok'
-  ) {
-    throw new Error('Health response did not match the expected contract.');
+  try {
+    const response = await requestApi('/health', { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new Error(`Health request failed with HTTP ${response.status}.`);
+    }
+
+    const payload: unknown = await response.json();
+
+    if (
+      typeof payload !== 'object' ||
+      payload === null ||
+      !('status' in payload) ||
+      payload.status !== 'ok'
+    ) {
+      throw new Error('Health response did not match the expected contract.');
+    }
+
+    return { status: 'ok' };
+  } catch (error) {
+    if (timedOut) {
+      throw new Error('Health request timed out.');
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    signal?.removeEventListener('abort', cancelFromCaller);
   }
-
-  return { status: 'ok' };
 }


### PR DESCRIPTION
## Summary

Implements the M0 mobile development health path and prevents an unreachable LAN backend from leaving the UI indefinitely in loading.

Closes #26.

## Changes

- Uses the existing typed `requestApi` abstraction for `GET /health`.
- Adds a health-specific five-second `AbortController` timeout; it does not impose a global policy on future endpoints.
- Propagates component unmount cancellation and cleans up timers and abort listeners.
- Shows the readable timeout state: `API health check failed: Health request timed out.`
- Preserves the accepted FastAPI contract, HTTP-error handling, invalid-payload handling, and direct platform network errors.
- Documents the timeout behavior alongside simulator/emulator and physical-device LAN setup.
- Adds focused timeout and unmount-cancellation Jest coverage.

## Validation

- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm test -- --runInBand --no-cache`: passed — 2 suites, 9 tests.
- Prettier passed for every changed file. Repository-wide `npm run format:check` in the Windows checkout still reports pre-existing CRLF drift in eight untouched files; the Linux CI format step passed.
- Backend CI / Backend CI — run 33245174477: passed.
- Mobile CI / mobile-quality — run 33245174455: passed.
- Database Migration CI / Database migration validation — run 33245174488: passed.
- Independent QA automated review: PASS.
- Physical Android/Expo Go smoke: PASS. With FastAPI running over LAN (`192.168.1.37:8000`), the app displayed `API is healthy.`. After stopping FastAPI and reloading, it transitioned out of loading and rendered `API health check failed: fetch failed: java.net.NoRouteToHostException: Host unreachable` without crashing. The platform reported the unreachable host before the five-second fallback timeout fired.

## Risks and assumptions

The FastAPI health contract remains `200 {"status":"ok"}`; no backend or CORS change is required for native iOS/Android clients. Physical devices require a reachable LAN IPv4 URL and host firewall access; `localhost` is not valid for a phone. Raw platform network detail is acceptable on this M0 development-status screen; product-facing error copy should be normalized when product networking UX is introduced.

## Rollback

Revert `22e799c` to remove the timeout correction, or revert both FND-010 commits to remove the health integration.