### PR TITLE
docs: plan M1 Identity milestone

### DIFF
--- a/docs/exec-plans/M1-identity.md
+++ b/docs/exec-plans/M1-identity.md
@@ -1,0 +1,157 @@
+# M1 Identity execution plan
+
+- Status: Planned
+- Milestone: M1
+- Parent issue: #36
+- Owners: project_manager + tech_lead
+
+## Objective
+
+Deliver the first visibly product-like Keylornet slice on a real phone while preserving ADR-002: Supabase Auth owns identity/token issuance and FastAPI owns application authorization.
+
+M1 is not complete merely because auth libraries are wired or CI passes. The user must be able to use the identity flow on a physical device.
+
+## Final physical-device demo gate
+
+The primary acceptance journey is:
+
+```text
+launch signed out
+-> welcome/auth UI
+-> register or sign in
+-> authenticated app shell
+-> protected FastAPI identity/profile
+-> edit profile
+-> restart app and remain signed in
+-> sign out
+-> sign in again
+```
+
+M1 must also independently prove:
+
+- password recovery from the physical development client;
+- account deletion using a disposable account;
+- invalid/missing/expired token behavior fails closed;
+- no privileged Supabase credential is present in the mobile bundle or repository.
+
+The primary launch experience must no longer be the M0 health diagnostics screen. Diagnostics may remain available as development tooling, but the app should now look and behave like an early product.
+
+## Product scope
+
+M1 implements:
+
+- email/password registration;
+- login/logout;
+- session persistence/refresh;
+- authenticated versus unauthenticated navigation;
+- basic server-backed profile;
+- password recovery;
+- account deletion/privacy flow;
+- server-side JWT validation and authorization foundation.
+
+M1 does not implement OAuth/social providers, exercise catalogue, workouts, groups, rankings, social feed, production deployment, or a final visual design system.
+
+## Architectural invariants
+
+1. Supabase Auth establishes identity and issues access tokens.
+2. FastAPI validates the token and derives the authenticated principal from it.
+3. Protected endpoints never trust a client-supplied owner/user identifier.
+4. Keylornet application user/profile data is owned by the application database and linked deterministically to the external auth subject.
+5. Privileged Supabase/service-role credentials remain server-side only.
+6. Public Expo configuration contains only values intentionally safe to ship in a client bundle.
+7. Any change to these boundaries requires ADR review rather than silent drift.
+
+## Work items and dependencies
+
+### IDN-001 — Identity contract and Supabase development configuration (#37)
+
+First gate. Make provider configuration, JWT verification, auth lifecycle, recovery/deep-link behavior, external-subject mapping and deletion authority implementation-ready. This work may expose a manual Supabase project provisioning step; if so, document the exact user action and never request privileged secrets in chat or commit them.
+
+### IDN-002 — Backend JWT validation and user/profile foundation (#38)
+
+Depends on IDN-001. Build fail-closed token validation, reusable authenticated principal, application user/profile persistence and the first protected identity endpoint. Real PostgreSQL integration tests apply where persistence semantics matter.
+
+### IDN-003 — Mobile auth UX/session/protected navigation (#39)
+
+Depends on IDN-001 and may run in parallel with IDN-002 in an isolated worktree. Build the visible signed-out and signed-in product shell, forms, session restoration, route protection and logout.
+
+**First visible product checkpoint:** after IDN-003, the phone should already show a real Keylornet welcome/login/register experience and authenticated shell, even before profile integration is complete.
+
+### IDN-004 — Authenticated profile API + mobile editing (#40)
+
+Depends on IDN-002 and IDN-003. Connect the authenticated mobile shell to FastAPI/PostgreSQL and provide a minimal editable profile with server-side validation and ownership protection.
+
+**Second visible checkpoint:** after IDN-004, signing in leads to a genuinely server-backed user experience rather than only an auth-provider session.
+
+### IDN-005 — Password recovery/deep links (#41)
+
+Depends on the stable IDN-001/IDN-003 auth lifecycle. Verify the complete recovery journey on the supported physical development client. If Expo Go cannot reliably satisfy the accepted redirect model, document the limitation and use the smallest supported development-build approach rather than weakening the security model.
+
+### IDN-006 — Account deletion/privacy flow (#42)
+
+Depends on the authenticated backend/mobile/profile foundation. Any provider-administration privilege remains server-side. Deletion semantics must be retry-safe and must not permit deletion of a different user by identifier manipulation.
+
+### IDN-007 — Integrated acceptance (#43)
+
+Final M1 gate. QA and security independently verify the complete physical-device journeys and update durable project state with real evidence. M2 must not begin until this gate passes.
+
+## Parallelization
+
+After IDN-001 is accepted:
+
+```text
+IDN-002 backend/data  \
+                       > parallel in isolated worktrees
+IDN-003 mobile UX     /
+```
+
+Then:
+
+```text
+IDN-002 + IDN-003 -> IDN-004
+IDN-003           -> IDN-005
+IDN-002 + IDN-003 + IDN-004 -> IDN-006
+all above -> IDN-007
+```
+
+Avoid concurrent edits to shared cross-cutting configuration without explicit coordination. Each implementation issue normally maps to one focused PR.
+
+## Review gates
+
+- IDN-001: tech_lead + security_engineer
+- IDN-002: security_engineer + qa_engineer; data_engineer owns migration semantics
+- IDN-003: qa_engineer
+- IDN-004: qa_engineer; security review for ownership/authorization findings
+- IDN-005: security_engineer + physical-device QA
+- IDN-006: mandatory security_engineer + qa_engineer
+- IDN-007: independent QA + security final acceptance
+
+Implementation agents do not self-approve.
+
+## CI and branch policy
+
+Every PR targets protected `main` and must receive the three authoritative required checks:
+
+- `Backend CI / Backend CI`
+- `Mobile CI / mobile-quality`
+- `Database Migration CI / Database migration validation`
+
+Strict branch protection and conversation resolution remain in force. No direct push to `main` is part of the normal workflow.
+
+## Definition of Done for M1
+
+M1 is complete only when:
+
+- IDN-001 through IDN-007 are accepted/closed;
+- physical-device registration/login/logout works;
+- session restoration across app restart works;
+- FastAPI authenticates the real access token and returns only the caller's protected identity/profile;
+- profile edits persist through PostgreSQL;
+- password recovery works end-to-end;
+- account deletion works for a disposable account;
+- invalid/missing/expired tokens fail closed;
+- no privileged auth secret is present in mobile/repository history introduced by M1;
+- all required CI is green;
+- security review has no blocking findings;
+- independent QA records the final physical-device evidence;
+- `PROJECT_STATE.md` records M1 completion before M2 starts.

--- a/docs/exec-plans/M1-identity.md
+++ b/docs/exec-plans/M1-identity.md
@@ -29,8 +29,11 @@ launch signed out
 
 M1 must also independently prove:
 
+- access-token expiry while the refresh session remains valid causes a successful session refresh and protected API access continues without user intervention;
+- refresh failure/invalid refresh credentials fail safely back to the signed-out state rather than leaving a stale authenticated shell;
 - password recovery from the physical development client;
 - account deletion using a disposable account;
+- after deletion, access tokens and refresh credentials issued before deletion cannot regain protected access or recreate application state, and a new password login for the deleted identity cannot restore the deleted Keylornet account under the accepted final semantics;
 - invalid/missing/expired token behavior fails closed;
 - no privileged Supabase credential is present in the mobile bundle or repository.
 
@@ -59,13 +62,16 @@ M1 does not implement OAuth/social providers, exercise catalogue, workouts, grou
 4. Keylornet application user/profile data is owned by the application database and linked deterministically to the external auth subject.
 5. Privileged Supabase/service-role credentials remain server-side only.
 6. Public Expo configuration contains only values intentionally safe to ship in a client bundle.
-7. Any change to these boundaries requires ADR review rather than silent drift.
+7. Account deletion has an explicit terminal identity state: valid-looking credentials issued before deletion must not be able to reprovision or regain a deleted Keylornet account.
+8. Any change to these boundaries requires ADR review rather than silent drift.
 
 ## Work items and dependencies
 
 ### IDN-001 — Identity contract and Supabase development configuration (#37)
 
-First gate. Make provider configuration, JWT verification, auth lifecycle, recovery/deep-link behavior, external-subject mapping and deletion authority implementation-ready. This work may expose a manual Supabase project provisioning step; if so, document the exact user action and never request privileged secrets in chat or commit them.
+First gate. Make provider configuration, JWT verification, access/refresh-token lifecycle, auth restoration, recovery/deep-link behavior, external-subject mapping, deleted-identity semantics and deletion authority implementation-ready. This work may expose a manual Supabase project provisioning step; if so, document the exact user action and never request privileged secrets in chat or commit them.
+
+The contract must define how access-token expiry is exercised in development, what happens when refresh succeeds or fails, and how FastAPI prevents a deleted external subject from recreating application state while old credentials are still cryptographically valid.
 
 ### IDN-002 — Backend JWT validation and user/profile foundation (#38)
 
@@ -73,9 +79,9 @@ Depends on IDN-001. Build fail-closed token validation, reusable authenticated p
 
 ### IDN-003 — Mobile auth UX/session/protected navigation (#39)
 
-Depends on IDN-001 and may run in parallel with IDN-002 in an isolated worktree. Build the visible signed-out and signed-in product shell, forms, session restoration, route protection and logout.
+Depends on IDN-001 and may run in parallel with IDN-002 in an isolated worktree. Build the visible signed-out and signed-in product shell, forms, session restoration, route protection, automatic session refresh and logout.
 
-**First visible product checkpoint:** after IDN-003, the phone should already show a real Keylornet welcome/login/register experience and authenticated shell, even before profile integration is complete.
+**First visible product checkpoint:** after IDN-003, the phone should already show a real Keylornet welcome/login/register experience and authenticated shell, even before profile integration is complete. Acceptance also exercises access-token expiry with a still-valid refresh session and a refresh-failure path back to signed out.
 
 ### IDN-004 — Authenticated profile API + mobile editing (#40)
 
@@ -89,11 +95,11 @@ Depends on the stable IDN-001/IDN-003 auth lifecycle. Verify the complete recove
 
 ### IDN-006 — Account deletion/privacy flow (#42)
 
-Depends on the authenticated backend/mobile/profile foundation. Any provider-administration privilege remains server-side. Deletion semantics must be retry-safe and must not permit deletion of a different user by identifier manipulation.
+Depends on the authenticated backend/mobile/profile foundation. Any provider-administration privilege remains server-side. Deletion semantics must be retry-safe, must not permit deletion of a different user by identifier manipulation, and must define a terminal deleted-identity behavior that rejects pre-deletion access/refresh credentials and prevents automatic reprovisioning of application state.
 
 ### IDN-007 — Integrated acceptance (#43)
 
-Final M1 gate. QA and security independently verify the complete physical-device journeys and update durable project state with real evidence. M2 must not begin until this gate passes.
+Final M1 gate. QA and security independently verify the complete physical-device journeys, including token refresh/refresh failure and post-deletion credential rejection, and update durable project state with real evidence. M2 must not begin until this gate passes.
 
 ## Parallelization
 
@@ -145,10 +151,13 @@ M1 is complete only when:
 - IDN-001 through IDN-007 are accepted/closed;
 - physical-device registration/login/logout works;
 - session restoration across app restart works;
+- access-token expiry is exercised while the refresh session is valid and protected API access continues after refresh;
+- refresh failure safely returns the user to signed out;
 - FastAPI authenticates the real access token and returns only the caller's protected identity/profile;
 - profile edits persist through PostgreSQL;
 - password recovery works end-to-end;
 - account deletion works for a disposable account;
+- pre-deletion access/refresh credentials cannot regain protected access or recreate deleted application state, and the accepted login-after-deletion behavior is verified;
 - invalid/missing/expired tokens fail closed;
 - no privileged auth secret is present in mobile/repository history introduced by M1;
 - all required CI is green;

--- a/docs/project-context/PROJECT_STATE.md
+++ b/docs/project-context/PROJECT_STATE.md
@@ -8,43 +8,29 @@ This is the fast handoff for resuming work. It is intentionally operational and 
 
 **M1 — Identity (planned; implementation not started)**
 
-M0 Foundation is complete. M1 is now explicitly prioritized for planning and will deliver the first visibly product-like Keylornet slice: real signed-out/authenticated navigation, Supabase-backed registration/login/session handling, FastAPI-authenticated profile operations, recovery, logout and account deletion.
+M0 Foundation is complete. M1 is the first user-facing product slice and is tracked by parent issue #36 and execution plan `docs/exec-plans/M1-identity.md`.
 
-M1 parent issue: #36. Durable execution plan: `docs/exec-plans/M1-identity.md`.
+M1 exit requires a real physical-device identity journey: signed-out launch, registration/login, authenticated app shell, FastAPI-backed profile, persisted profile editing, session restoration and refresh, logout/login, password recovery, account deletion, and independent QA/security acceptance.
 
-### M1 work items
+The milestone must explicitly exercise access-token expiry with a valid refresh session, safe behavior when refresh fails, and post-deletion rejection of credentials issued before deletion so deleted identity state cannot be silently reprovisioned.
 
-- #37 IDN-001 — identity contract and Supabase development configuration
-- #38 IDN-002 — backend JWT validation and application-user/profile foundation
-- #39 IDN-003 — mobile auth UX, session persistence and protected navigation
-- #40 IDN-004 — authenticated profile API and mobile profile editing
-- #41 IDN-005 — password recovery and auth deep-link handling
-- #42 IDN-006 — account deletion and identity privacy flow
-- #43 IDN-007 — end-to-end, security and physical-device acceptance
+Planned work:
+
+- #37 IDN-001 identity contract and Supabase development configuration
+- #38 IDN-002 backend JWT validation and application-user/profile foundation
+- #39 IDN-003 mobile auth UX, session persistence/refresh and protected navigation
+- #40 IDN-004 authenticated profile API and mobile profile editing
+- #41 IDN-005 password recovery and auth deep-link handling
+- #42 IDN-006 account deletion and identity privacy flow
+- #43 IDN-007 M1 end-to-end, security and physical-device acceptance
 
 Dependency shape:
 
-`#37 -> (#38 || #39) -> #40`, with #41 following the mobile auth lifecycle, #42 following the authenticated profile foundation, and #43 as the final integrated gate.
+`#37 -> (#38 || #39) -> #40`; `#39 -> #41`; `#38 + #39 + #40 -> #42`; all implementation work -> #43.
 
-The first visible product checkpoint is IDN-003: the physical phone should show a real Keylornet welcome/login/register experience and authenticated shell rather than the M0 diagnostics screen. M1 is not complete until the physical-device demo gate in `M1-identity.md` passes.
+Do not start M2 until #43 passes and M1 completion evidence is recorded here.
 
-## M0 — Foundation (complete)
-
-M0 established the reproducible professional baseline required before product features:
-
-- backend skeleton
-- mobile skeleton
-- PostgreSQL/Alembic baseline
-- reproducible local Docker/PostgreSQL environment
-- backend CI
-- mobile CI
-- database migration CI
-- real mobile-to-API health path
-- coherent test architecture
-- protected `main` using real CI checks
-- independent QA/review gates
-
-### Merged foundation work
+## Completed M0 foundation
 
 - FND-003 FastAPI skeleton — merged
 - FND-004 Expo/React Native mobile skeleton — merged
@@ -59,23 +45,21 @@ M0 established the reproducible professional baseline required before product fe
 - FND-012 Protect `main` — effective branch protection validated through disposable PR #34; pull requests, strict CI checks, and resolved conversations are required without a mandatory approving review
 - DOC-001 durable project context — merged; future sessions must read `docs/project-context/`
 
-## FND-012 effective protection and validation
+## Effective branch protection and CI
 
-`main` is protected by classic GitHub branch protection; no repository ruleset also affects it. The GitHub Actions check-run identities configured by the REST API map to the following authoritative workflow/job names shown in pull requests:
+`main` is protected by classic GitHub branch protection; no repository ruleset also affects it.
 
-- `Backend CI / Backend CI` — check-run `Backend CI`
-- `Mobile CI / mobile-quality` — check-run `mobile-quality`
-- `Database Migration CI / Database migration validation` — check-run `Database migration validation`
+Authoritative pull-request workflow/job checks:
 
-The effective policy requires a pull request, requires all three checks with strict up-to-date branches, and requires all review conversations to be resolved. It has zero required approvals, does not require CODEOWNERS or signed commits, and has no bypass actors. Administrators are included in enforcement, so normal direct and force pushes are blocked; a repository administrator can still recover by editing the repository's protection settings. Deletion of `main` is disabled.
+- `Backend CI / Backend CI`
+- `Mobile CI / mobile-quality`
+- `Database Migration CI / Database migration validation`
 
-Disposable validation PR #34 was created from protected `main` at `cda8611fb46cbd8bcd493d57a1cff12ee79d6aa0`. While its three checks were pending, GitHub reported the PR as blocked. The real workflow runs all passed:
+The policy requires a pull request, requires all three checks with strict up-to-date branches, and requires all review conversations to be resolved. It has zero required approvals, no CODEOWNERS or signed-commit requirement, and no bypass actors. Administrators are included in enforcement; normal direct/force pushes and deletion of `main` are blocked, while a repository administrator can still recover by editing repository settings.
 
-- Backend CI: run `33269877012`
-- Mobile CI: run `33269877008`
-- Database Migration CI: run `33269877007`
+Disposable validation PR #34 proved the three checks appear while pending, block merging until green, and conversation resolution also blocks merging. After all checks passed and the temporary review thread was resolved, GitHub reported the PR merge-clean without an approving review requirement.
 
-Each relevant job step completed successfully, including the database migration execution and Alembic-head verification. After a temporary review thread was resolved, GitHub reported the PR as merge-clean without requesting an approving review. The disposable branch and PR were closed after recording the evidence.
+M0 physical-device/API and branch-protection evidence is complete.
 
 ## Roadmap after M1
 

--- a/docs/project-context/PROJECT_STATE.md
+++ b/docs/project-context/PROJECT_STATE.md
@@ -6,11 +6,31 @@ This is the fast handoff for resuming work. It is intentionally operational and 
 
 ## Current milestone
 
-**M0 — Foundation (complete)**
+**M1 — Identity (planned; implementation not started)**
 
-Goal: establish a reproducible professional baseline before implementing identity or product-domain features.
+M0 Foundation is complete. M1 is now explicitly prioritized for planning and will deliver the first visibly product-like Keylornet slice: real signed-out/authenticated navigation, Supabase-backed registration/login/session handling, FastAPI-authenticated profile operations, recovery, logout and account deletion.
 
-M0 gate includes:
+M1 parent issue: #36. Durable execution plan: `docs/exec-plans/M1-identity.md`.
+
+### M1 work items
+
+- #37 IDN-001 — identity contract and Supabase development configuration
+- #38 IDN-002 — backend JWT validation and application-user/profile foundation
+- #39 IDN-003 — mobile auth UX, session persistence and protected navigation
+- #40 IDN-004 — authenticated profile API and mobile profile editing
+- #41 IDN-005 — password recovery and auth deep-link handling
+- #42 IDN-006 — account deletion and identity privacy flow
+- #43 IDN-007 — end-to-end, security and physical-device acceptance
+
+Dependency shape:
+
+`#37 -> (#38 || #39) -> #40`, with #41 following the mobile auth lifecycle, #42 following the authenticated profile foundation, and #43 as the final integrated gate.
+
+The first visible product checkpoint is IDN-003: the physical phone should show a real Keylornet welcome/login/register experience and authenticated shell rather than the M0 diagnostics screen. M1 is not complete until the physical-device demo gate in `M1-identity.md` passes.
+
+## M0 — Foundation (complete)
+
+M0 established the reproducible professional baseline required before product features:
 
 - backend skeleton
 - mobile skeleton
@@ -24,7 +44,7 @@ M0 gate includes:
 - protected `main` using real CI checks
 - independent QA/review gates
 
-## Merged foundation work
+### Merged foundation work
 
 - FND-003 FastAPI skeleton — merged
 - FND-004 Expo/React Native mobile skeleton — merged
@@ -41,42 +61,24 @@ M0 gate includes:
 
 ## FND-012 effective protection and validation
 
-`main` is protected by classic GitHub branch protection; no repository ruleset
-also affects it. The GitHub Actions check-run identities configured by the REST
-API map to the following authoritative workflow/job names shown in pull
-requests:
+`main` is protected by classic GitHub branch protection; no repository ruleset also affects it. The GitHub Actions check-run identities configured by the REST API map to the following authoritative workflow/job names shown in pull requests:
 
 - `Backend CI / Backend CI` — check-run `Backend CI`
 - `Mobile CI / mobile-quality` — check-run `mobile-quality`
 - `Database Migration CI / Database migration validation` — check-run `Database migration validation`
 
-The effective policy requires a pull request, requires all three checks with
-strict up-to-date branches, and requires all review conversations to be
-resolved. It has zero required approvals, does not require CODEOWNERS or signed
-commits, and has no bypass actors. Administrators are included in enforcement,
-so normal direct and force pushes are blocked; a repository administrator can
-still recover by editing the repository's protection settings. Deletion of
-`main` is disabled.
+The effective policy requires a pull request, requires all three checks with strict up-to-date branches, and requires all review conversations to be resolved. It has zero required approvals, does not require CODEOWNERS or signed commits, and has no bypass actors. Administrators are included in enforcement, so normal direct and force pushes are blocked; a repository administrator can still recover by editing the repository's protection settings. Deletion of `main` is disabled.
 
-Disposable validation PR #34 was created from current protected `main` at
-`cda8611fb46cbd8bcd493d57a1cff12ee79d6aa0`. While its three checks were
-pending, GitHub reported the PR as blocked. The real workflow runs all passed:
+Disposable validation PR #34 was created from protected `main` at `cda8611fb46cbd8bcd493d57a1cff12ee79d6aa0`. While its three checks were pending, GitHub reported the PR as blocked. The real workflow runs all passed:
 
 - Backend CI: run `33269877012`
 - Mobile CI: run `33269877008`
 - Database Migration CI: run `33269877007`
 
-Each relevant job step completed successfully, including the database migration
-execution and Alembic-head verification. After a temporary review thread was
-resolved, GitHub reported the PR as merge-clean without requesting an approving
-review. The disposable branch and PR are closed after this evidence is recorded.
+Each relevant job step completed successfully, including the database migration execution and Alembic-head verification. After a temporary review thread was resolved, GitHub reported the PR as merge-clean without requesting an approving review. The disposable branch and PR were closed after recording the evidence.
 
-All M0 gates are satisfied. Do not start M1 implementation until explicitly
-prioritized.
+## Roadmap after M1
 
-## Roadmap after M0
-
-- M1 Identity
 - M2 Exercise Catalog
 - M3 Workout Engine
 - M4 History / Analytics


### PR DESCRIPTION
Adds the durable M1 Identity execution plan after M0 completion.

The plan is grounded in accepted ADR-002 and the MVP identity requirements, links parent issue #36 and child issues #37–#43, defines dependency/parallelization order, and makes physical-device product demos explicit milestone gates.

No application behavior changes.