### PR TITLE
BRAND-001 — Rename product to KeylorFit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# keylornet
+# KeylorFit
 
 ## Local PostgreSQL
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,6 +1,6 @@
-# Keylornet mobile
+# KeylorFit mobile
 
-Expo/React Native client for Keylornet. The primary route is the M1
+Expo/React Native client for KeylorFit. The primary route is the M1
 email/password identity flow; the M0 health diagnostic is no longer the normal
 entry experience.
 
@@ -62,8 +62,8 @@ the authenticated shell and can sign out. Session refresh is active only while
 the app is foregrounded. A definitive refresh failure clears the local
 authenticated state and returns to sign-in.
 
-For confirmation or password-recovery deep links, use a Keylornet development
-build with the `keylornet` scheme; Expo Go does not provide the stable callback
+For confirmation or password-recovery deep links, use a KeylorFit development
+build with the `keylorfit` scheme; Expo Go does not provide the stable callback
 URL required by the M1 contract.
 
 ## Validation

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -6,6 +6,9 @@
     "scheme": "keylorfit",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
+    "android": {
+      "package": "com.jonathansalgadonieto.keylorfit"
+    },
     "plugins": ["expo-router"],
     "experiments": {
       "typedRoutes": true

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,9 +1,9 @@
 {
   "expo": {
-    "name": "Keylornet",
-    "slug": "keylornet",
+    "name": "KeylorFit",
+    "slug": "keylorfit",
     "version": "0.1.0",
-    "scheme": "keylornet",
+    "scheme": "keylorfit",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "plugins": ["expo-router"],

--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -19,7 +19,7 @@ function HomeScreen() {
       <Text accessibilityRole="header" style={styles.title}>
         Your training home
       </Text>
-      <Text style={styles.message}>You are signed in to Keylornet.</Text>
+      <Text style={styles.message}>You are signed in to KeylorFit.</Text>
       {error ? (
         <Text accessibilityLiveRegion="polite" style={styles.error}>
           {error}

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -11,7 +11,7 @@ function SignInScreen() {
 
   return (
     <AuthScreen
-      subtitle="Use your Keylornet email and password."
+      subtitle="Use your KeylorFit email and password."
       title="Sign in"
     >
       {feedback ? (

--- a/apps/mobile/app/sign-up.tsx
+++ b/apps/mobile/app/sign-up.tsx
@@ -11,7 +11,7 @@ function SignUpScreen() {
 
   return (
     <AuthScreen
-      subtitle="Create a Keylornet account with an email address and password."
+      subtitle="Create a KeylorFit account with an email address and password."
       title="Create your account"
     >
       <EmailPasswordForm

--- a/apps/mobile/components/__tests__/development-status.test.tsx
+++ b/apps/mobile/components/__tests__/development-status.test.tsx
@@ -17,7 +17,7 @@ describe('DevelopmentStatus', () => {
       <DevelopmentStatus loadHealth={async () => ({ status: 'ok' })} />,
     );
 
-    expect(getByText('Keylornet mobile')).toBeTruthy();
+    expect(getByText('KeylorFit mobile')).toBeTruthy();
 
     await waitFor(() => {
       expect(getByText('API is healthy.')).toBeTruthy();

--- a/apps/mobile/components/auth/auth-screen.tsx
+++ b/apps/mobile/components/auth/auth-screen.tsx
@@ -11,7 +11,7 @@ export function AuthScreen({ children, subtitle, title }: AuthScreenProps) {
     <View style={styles.container}>
       <View style={styles.content}>
         <Text accessibilityRole="header" style={styles.brand}>
-          Keylornet
+          KeylorFit
         </Text>
         <Text accessibilityRole="header" style={styles.title}>
           {title}

--- a/apps/mobile/components/auth/session-restoring.tsx
+++ b/apps/mobile/components/auth/session-restoring.tsx
@@ -7,7 +7,7 @@ export function SessionRestoring() {
         accessibilityLabel="Restoring your session"
         size="large"
       />
-      <Text style={styles.title}>Keylornet</Text>
+      <Text style={styles.title}>KeylorFit</Text>
       <Text accessibilityLiveRegion="polite" style={styles.message}>
         Restoring your session…
       </Text>

--- a/apps/mobile/components/development-status.tsx
+++ b/apps/mobile/components/development-status.tsx
@@ -75,7 +75,7 @@ export function DevelopmentStatus({
 
   return (
     <View style={styles.container} accessibilityRole="summary">
-      <Text style={styles.heading}>Keylornet mobile</Text>
+      <Text style={styles.heading}>KeylorFit mobile</Text>
       {visibleHealthState.kind === 'loading' ? (
         <Text accessibilityLiveRegion="polite" style={styles.message}>
           Checking API health…

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@keylornet/mobile",
+  "name": "@keylorfit/mobile",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@keylornet/mobile",
+      "name": "@keylorfit/mobile",
       "version": "0.1.0",
       "dependencies": {
         "@expo/metro-runtime": "57.0.14",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@keylornet/mobile",
+  "name": "@keylorfit/mobile",
   "version": "0.1.0",
   "private": true,
   "main": "expo-router/entry",

--- a/database/README.md
+++ b/database/README.md
@@ -1,6 +1,6 @@
 # Database baseline
 
-This package owns Keylornet's PostgreSQL connection configuration, SQLAlchemy
+This package owns KeylorFit's PostgreSQL connection configuration, SQLAlchemy
 metadata conventions and Alembic migration history. PostgreSQL is the server
 source of truth; SQLite is not a supported substitute for database integration
 tests.

--- a/database/pyproject.toml
+++ b/database/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "keylornet-database"
 version = "0.1.0"
-description = "PostgreSQL and Alembic foundation for Keylornet"
+description = "PostgreSQL and Alembic foundation for KeylorFit"
 requires-python = ">=3.11,<3.14"
 dependencies = [
   "alembic==1.16.4",

--- a/database/src/keylornet_database/__init__.py
+++ b/database/src/keylornet_database/__init__.py
@@ -1,4 +1,4 @@
-"""PostgreSQL configuration and migration primitives for Keylornet."""
+"""PostgreSQL configuration and migration primitives for KeylorFit."""
 
 from keylornet_database.config import DatabaseSettings, Environment
 from keylornet_database.identity import ApplicationUserRepository, TerminalIdentityError

--- a/database/src/keylornet_database/identity.py
+++ b/database/src/keylornet_database/identity.py
@@ -83,6 +83,6 @@ class ApplicationUserRepository:
         user = identity.user
         if user.lifecycle_state is not ApplicationUserLifecycle.ACTIVE:
             raise TerminalIdentityError(
-                "the external identity has a terminal Keylornet lifecycle state"
+                "the external identity has a terminal KeylorFit lifecycle state"
             )
         return user

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,7 +4,7 @@ This directory is the source of truth for system-wide technical decisions.
 
 ## Baseline architecture
 
-Keylornet is designed as a modular monolith with a mobile client and a server-side API:
+KeylorFit is designed as a modular monolith with a mobile client and a server-side API:
 
 ```text
 React Native / Expo / TypeScript

--- a/docs/architecture/foundation-test-architecture.md
+++ b/docs/architecture/foundation-test-architecture.md
@@ -6,7 +6,7 @@
 
 ## Purpose and scope
 
-This document defines the test foundation for Keylornet's modular monolith and
+This document defines the test foundation for KeylorFit's modular monolith and
 mobile client. It complements the accepted architecture decisions; it does not
 change API, database, authentication, or offline-sync contracts.
 

--- a/docs/design-docs/M1-identity-contract.md
+++ b/docs/design-docs/M1-identity-contract.md
@@ -12,7 +12,7 @@ This document turns ADR-002 into an implementation contract for M1. It does not 
 
 The invariant remains:
 
-`Supabase Auth authenticates -> FastAPI validates identity and authorizes -> Keylornet PostgreSQL stores application identity/profile data`
+`Supabase Auth authenticates -> FastAPI validates identity and authorizes -> KeylorFit PostgreSQL stores application identity/profile data`
 
 The mobile app is never authoritative for ownership or user identity.
 
@@ -29,19 +29,19 @@ For the Expo client, use the current Supabase React Native approach:
 - `detectSessionInUrl: false`
 - explicit app-state handling so refresh work is active while the app is foregrounded and stopped while backgrounded where appropriate
 
-The repository currently has Expo SDK 57 / React Native 0.86 and already declares the custom app scheme `keylornet` in `apps/mobile/app.json`.
+The repository currently has Expo SDK 57 / React Native 0.86 and declares the custom app scheme `keylorfit` in `apps/mobile/app.json`.
 
 ## Observed Supabase development-project state
 
-The connected Keylornet development project is active in `eu-central-1` and exposes a modern publishable API key. During IDN-001 setup, the Authentication dashboard was checked manually and confirmed:
+The connected development project is active in `eu-central-1` and exposes a modern publishable API key. Its currently visible management label remains Keylornet until the BRAND-001 manual Supabase update is completed. During IDN-001 setup, the Authentication dashboard was checked manually and confirmed:
 
 - Email/password provider enabled.
 - Email confirmation enabled.
-- Redirect URLs configured for `keylornet://auth/confirm` and `keylornet://auth/recovery`.
+- Redirect URLs configured for the then-current Keylornet callbacks.
 - Current JWT signing key is asymmetric ECC P-256, suitable for public JWKS verification.
 - A legacy HS256 shared-secret signing key remains only under **Previously used keys** after rotation; it is not the current signing key.
 
-Do not revoke the previous legacy key merely to finish IDN-001. Revocation is a separate cleanup step and must happen only after legacy API-key dependencies and outstanding token lifetime have been considered. New Keylornet implementation must use the publishable-key + asymmetric-JWKS model and must not add new dependencies on legacy `anon`, `service_role`, or shared JWT-secret verification.
+Do not revoke the previous legacy key merely to finish IDN-001. Revocation is a separate cleanup step and must happen only after legacy API-key dependencies and outstanding token lifetime have been considered. New KeylorFit implementation must use the publishable-key + asymmetric-JWKS model and must not add new dependencies on legacy `anon`, `service_role`, or shared JWT-secret verification.
 
 ## Public, backend, and privileged configuration
 
@@ -76,21 +76,21 @@ A privileged Supabase secret must:
 - never use an `EXPO_PUBLIC_` prefix;
 - never be committed;
 - never be put in PR descriptions, issue comments, screenshots, logs, or chat;
-- be used only by backend code that has already authenticated and authorized the requesting Keylornet user.
+- be used only by backend code that has already authenticated and authorized the requesting KeylorFit user.
 
 The secret value does not need to be copied out of the Supabase dashboard during IDN-001. Provision it into backend-only local/deployment secret storage when IDN-006 actually needs administrative deletion capability, minimizing unnecessary exposure.
 
 ## Development Supabase project requirements
 
-Use the existing dedicated Keylornet development project for M1 acceptance.
+Use the existing dedicated development project for KeylorFit M1 acceptance.
 
 Required dashboard state:
 
 1. Email/password authentication enabled.
 2. Email confirmation enabled for the real M1 confirmation flow.
 3. Current publishable API key available for the Expo client.
-4. Current asymmetric JWT signing-key system active; Keylornet expects a JWKS endpoint with public verification keys.
-5. Redirect URLs configured for the Keylornet custom scheme used by the development build.
+4. Current asymmetric JWT signing-key system active; KeylorFit expects a JWKS endpoint with public verification keys.
+5. Redirect URLs configured for the KeylorFit custom scheme used by the development build, with legacy callbacks retained only for a controlled development-build transition.
 6. A server secret key can be provisioned later for the deletion flow; do not put it in mobile configuration and do not expose it early without a consumer.
 
 Do not alter auth timeouts/session policy simply to make tests pass. Use normal provider behavior unless a specific acceptance test needs a temporary, documented development setting.
@@ -99,18 +99,18 @@ Do not alter auth timeouts/session policy simply to make tests pass. Use normal 
 
 The repository already declares:
 
-`scheme: keylornet`
+`scheme: keylorfit`
 
 Use stable app callbacks under that scheme:
 
-- `keylornet://auth/confirm`
-- `keylornet://auth/recovery`
+- `keylorfit://auth/confirm`
+- `keylorfit://auth/recovery`
 
 Exact route filenames may be adjusted by IDN-003/IDN-005 while preserving these semantic endpoints.
 
 For provider redirects requiring a stable callback URL, the supported M1 physical-device client is a development build, not Expo Go. Expo Go uses an `exp://` URL whose address is not stable enough to be the durable authentication callback contract. Expo Go can still be used for flows that do not depend on stable provider redirects, but IDN-005 recovery acceptance must use the supported development build if required.
 
-Supabase Auth Redirect URLs must allow the Keylornet custom scheme for the M1 development project. Use the narrowest practical allowed callback set rather than an unnecessarily broad production wildcard.
+Supabase Auth Redirect URLs must allow the KeylorFit custom scheme for the M1 development project. Use the narrowest practical allowed callback set rather than an unnecessarily broad production wildcard. During the installed-build transition, retain the old Keylornet callbacks only until no accepted development build depends on them; do not add wildcards.
 
 ## Registration and email confirmation
 
@@ -121,7 +121,7 @@ Expected states:
 1. User submits email/password.
 2. Supabase returns either a usable session or a confirmation-required state according to project settings.
 3. When confirmation is required, the app displays an explicit pending-confirmation state rather than pretending the user is authenticated.
-4. The confirmation link returns to the Keylornet development build through the configured deep link.
+4. The confirmation link returns to the KeylorFit development build through the configured deep link.
 5. The resulting Supabase session becomes the only source of authenticated client identity.
 
 Provider errors must be mapped to understandable UI errors. Do not reveal internal provider responses or credentials verbatim to users.
@@ -173,22 +173,22 @@ The authenticated principal is derived from the validated JWT `sub`; a `user_id`
 
 JWKS lookup/caching must permit Supabase signing-key rotation. Do not cache keys indefinitely.
 
-A valid signature alone is not sufficient to resurrect a deleted Keylornet identity; see deletion semantics below.
+A valid signature alone is not sufficient to resurrect a deleted KeylorFit identity; see deletion semantics below.
 
 ## Application user/profile mapping
 
-Keylornet maintains its own application identity row independently of the Supabase Auth schema.
+KeylorFit maintains its own application identity row independently of the Supabase Auth schema.
 
 Recommended M1 mapping:
 
-- internal Keylornet user ID: application-owned UUID primary key;
+- internal KeylorFit user ID: application-owned UUID primary key;
 - external auth provider: `supabase`;
 - external subject: Supabase JWT `sub`, unique and immutable for the mapping;
-- profile: application-owned profile data linked to the Keylornet user.
+- profile: application-owned profile data linked to the KeylorFit user.
 
 Do not use email as the stable foreign identity key because email can change.
 
-First authenticated access may provision the Keylornet application user/profile deterministically if no active mapping exists. The operation must be transaction-safe/idempotent so concurrent requests do not create duplicates.
+First authenticated access may provision the KeylorFit application user/profile deterministically if no active mapping exists. The operation must be transaction-safe/idempotent so concurrent requests do not create duplicates.
 
 A deleted/tombstoned external subject must never be eligible for automatic reprovisioning.
 
@@ -214,8 +214,8 @@ Avoid exposing provider-specific debugging information to the mobile UI.
 M1 recovery uses Supabase's password-reset flow.
 
 1. Signed-out user submits email.
-2. Mobile requests password recovery with a stable redirect target such as `keylornet://auth/recovery`.
-3. Email link opens the supported Keylornet development build.
+2. Mobile requests password recovery with a stable redirect target such as `keylorfit://auth/recovery`.
+3. Email link opens the supported KeylorFit development build.
 4. The app recognizes the recovery auth state and displays a new-password form.
 5. The authenticated recovery context updates the password through the supported Supabase API.
 6. Expired, reused, malformed, or wrong-flow links produce a safe recovery error and cannot enter normal protected navigation accidentally.
@@ -245,9 +245,9 @@ The exact minimal tombstone representation and retention policy must be reviewed
 
 IDN-006/IDN-007 must prove that:
 
-- an access token issued before deletion cannot regain protected Keylornet access even if its signature and `exp` would otherwise still be acceptable;
-- the old refresh credential/session cannot mint a usable Keylornet session after provider deletion;
-- logging in again with the deleted account's old credentials does not silently recreate the deleted Keylornet account under the chosen deletion semantics;
+- an access token issued before deletion cannot regain protected KeylorFit access even if its signature and `exp` would otherwise still be acceptable;
+- the old refresh credential/session cannot mint a usable KeylorFit session after provider deletion;
+- logging in again with the deleted account's old credentials does not silently recreate the deleted KeylorFit account under the chosen deletion semantics;
 - retries cannot delete a different user's identity.
 
 ## Failure behavior
@@ -268,7 +268,7 @@ Backend never converts token-verification exceptions into authenticated anonymou
 
 ## Physical-device development runbook
 
-For normal auth UI/session work, Expo Go may remain useful where no stable callback is needed. For confirmation/recovery/deep-link acceptance, use a Keylornet development build carrying the `keylornet` scheme.
+For normal auth UI/session work, Expo Go may remain useful where no stable callback is needed. For confirmation/recovery/deep-link acceptance, use a KeylorFit development build carrying the `keylorfit` scheme.
 
 The local FastAPI URL on a physical phone remains the development machine's reachable LAN IPv4, as established in M0.
 
@@ -276,14 +276,44 @@ The Supabase project URL is internet-reachable and independent of the LAN API UR
 
 ## Manual provisioning checklist
 
-The connected Keylornet Supabase project has been configured for M1 as follows:
+The connected Supabase development project has the following M1 baseline. BRAND-001 must read back the live Auth URL and email-template configuration before marking the KeylorFit transition complete:
 
 1. Email provider/password auth enabled.
 2. Email confirmation enabled.
 3. Project URL and modern publishable key available through project configuration.
 4. Current asymmetric ECC P-256 signing key confirmed in JWT settings.
-5. Auth redirect URL settings include `keylornet://auth/confirm` and `keylornet://auth/recovery`.
+5. Auth redirect URL settings must include `keylorfit://auth/confirm` and `keylorfit://auth/recovery`. Keep the legacy Keylornet callbacks only while an accepted installed development build still uses them.
 6. Any future `sb_secret_...` administrative credential remains server-only and should only be copied into secret storage when IDN-006 needs it.
+
+### BRAND-001 Supabase Auth transition boundary
+
+The repository cannot safely read or mutate the hosted Auth URL or email-template
+configuration through its configured Supabase tooling. Before physical callback
+acceptance, the Product Owner must use the Supabase dashboard for the connected
+development project and record a read-back of the resulting settings:
+
+1. Open **Authentication > URL Configuration**. Add the exact narrow redirect
+   URLs `keylorfit://auth/confirm` and `keylorfit://auth/recovery`. Do not add
+   wildcard redirect URLs.
+2. Retain `keylornet://auth/confirm` and `keylornet://auth/recovery` only while
+   an accepted installed development build still uses the old scheme. Do not
+   remove either legacy URL until that build inventory is empty.
+3. Where supported, change the Auth project/application display label to
+   **KeylorFit**. Under **Authentication > Email Templates**, update the
+   confirmation subject and visible body copy to identify KeylorFit while
+   preserving the provider-generated `{{ .ConfirmationURL }}` placeholder and
+   link. Do not expose or rotate any secret, and do not change the sender/domain
+   configuration as part of this transition.
+4. Read the URL allow-list and confirmation template back after saving. Record
+   the exact callbacks present, the KeylorFit subject/body branding, and whether
+   legacy callbacks remain for installed builds. If the new build cannot open
+   its scheme, roll back by retaining the legacy allow-list entries; do not
+   weaken allow-listing with a wildcard.
+
+This is configuration preparation only. IDN-003A (#49) remains responsible for
+passing `emailRedirectTo`, consuming confirmation links, and proving the
+end-to-end confirmation journey. IDN-005 remains responsible for recovery-link
+handling.
 
 Store locally when implementation starts:
 

--- a/docs/exec-plans/M1-identity.md
+++ b/docs/exec-plans/M1-identity.md
@@ -7,7 +7,7 @@
 
 ## Objective
 
-Deliver the first visibly product-like Keylornet slice on a real phone while preserving ADR-002: Supabase Auth owns identity/token issuance and FastAPI owns application authorization.
+Deliver the first visibly product-like KeylorFit slice on a real phone while preserving ADR-002: Supabase Auth owns identity/token issuance and FastAPI owns application authorization.
 
 M1 is not complete merely because auth libraries are wired or CI passes. The user must be able to use the identity flow on a physical device.
 
@@ -33,7 +33,7 @@ M1 must also independently prove:
 - refresh failure/invalid refresh credentials fail safely back to the signed-out state rather than leaving a stale authenticated shell;
 - password recovery from the physical development client;
 - account deletion using a disposable account;
-- after deletion, access tokens and refresh credentials issued before deletion cannot regain protected access or recreate application state, and a new password login for the deleted identity cannot restore the deleted Keylornet account under the accepted final semantics;
+- after deletion, access tokens and refresh credentials issued before deletion cannot regain protected access or recreate application state, and a new password login for the deleted identity cannot restore the deleted KeylorFit account under the accepted final semantics;
 - invalid/missing/expired token behavior fails closed;
 - no privileged Supabase credential is present in the mobile bundle or repository.
 
@@ -59,10 +59,10 @@ M1 does not implement OAuth/social providers, exercise catalogue, workouts, grou
 1. Supabase Auth establishes identity and issues access tokens.
 2. FastAPI validates the token and derives the authenticated principal from it.
 3. Protected endpoints never trust a client-supplied owner/user identifier.
-4. Keylornet application user/profile data is owned by the application database and linked deterministically to the external auth subject.
+4. KeylorFit application user/profile data is owned by the application database and linked deterministically to the external auth subject.
 5. Privileged Supabase/service-role credentials remain server-side only.
 6. Public Expo configuration contains only values intentionally safe to ship in a client bundle.
-7. Account deletion has an explicit terminal identity state: valid-looking credentials issued before deletion must not be able to reprovision or regain a deleted Keylornet account.
+7. Account deletion has an explicit terminal identity state: valid-looking credentials issued before deletion must not be able to reprovision or regain a deleted KeylorFit account.
 8. Any change to these boundaries requires ADR review rather than silent drift.
 
 ## Work items and dependencies
@@ -81,7 +81,7 @@ Depends on IDN-001. Build fail-closed token validation, reusable authenticated p
 
 Depends on IDN-001 and may run in parallel with IDN-002 in an isolated worktree. Build the visible signed-out and signed-in product shell, forms, session restoration, route protection, automatic session refresh and logout.
 
-**First visible product checkpoint:** after IDN-003, the phone should already show a real Keylornet welcome/login/register experience and authenticated shell, even before profile integration is complete. Acceptance also exercises access-token expiry with a still-valid refresh session and a refresh-failure path back to signed out.
+**First visible product checkpoint:** after IDN-003, the phone should already show a real KeylorFit welcome/login/register experience and authenticated shell, even before profile integration is complete. Acceptance also exercises access-token expiry with a still-valid refresh session and a refresh-failure path back to signed out.
 
 ### IDN-004 — Authenticated profile API + mobile editing (#40)
 

--- a/docs/product-specs/MVP.md
+++ b/docs/product-specs/MVP.md
@@ -1,8 +1,8 @@
-# Keylornet MVP Product Specification
+# KeylorFit MVP Product Specification
 
 ## Product goal
 
-Keylornet is a mobile application for recording gym training, reviewing personal history and progress, and comparing activity and performance within groups. Social sharing is a later layer built on top of trustworthy workout data.
+KeylorFit is a mobile application for recording gym training, reviewing personal history and progress, and comparing activity and performance within groups. Social sharing is a later layer built on top of trustworthy workout data.
 
 ## MVP priorities
 

--- a/docs/project-context/PRODUCT_VISION.md
+++ b/docs/project-context/PRODUCT_VISION.md
@@ -1,8 +1,8 @@
-# Keylornet product vision
+# KeylorFit product vision
 
 ## Product in one sentence
 
-Keylornet is a mobile-first gym training product where users can reliably record workouts, understand their progress, compare meaningful performance with groups, and optionally share training-related social content.
+KeylorFit is a mobile-first gym training product where users can reliably record workouts, understand their progress, compare meaningful performance with groups, and optionally share training-related social content.
 
 The product is not intended to be a generic social network with a workout form attached. The training record is the core domain and source of value; competition, analytics and social features are built on top of trustworthy workout data.
 
@@ -105,11 +105,11 @@ This protects the product from later schema redesign for running, cycling, plank
 
 ## Exercise catalogue intent
 
-The app should have its own internal exercise catalogue. A source such as wger may be useful for bootstrapping data, but Keylornet must not depend on an external exercise API at runtime.
+The app should have its own internal exercise catalogue. A source such as wger may be useful for bootstrapping data, but KeylorFit must not depend on an external exercise API at runtime.
 
 The intended ingestion model is:
 
-`external/open source -> importer -> normalization -> Keylornet database -> curation`
+`external/open source -> importer -> normalization -> KeylorFit database -> curation`
 
 Licensing for descriptions and media must be checked independently before redistribution.
 

--- a/docs/project-context/PROJECT_STATE.md
+++ b/docs/project-context/PROJECT_STATE.md
@@ -1,6 +1,6 @@
-# Keylornet project state
+# KeylorFit project state
 
-Last updated: 2026-08-29
+Last updated: 2026-08-30
 
 This is the fast handoff for resuming work. It is intentionally operational and may become stale if not updated after merges; GitHub issues, PRs and `main` are the final authority for real-time status.
 

--- a/docs/project-context/README.md
+++ b/docs/project-context/README.md
@@ -1,4 +1,4 @@
-# Keylornet project context
+# KeylorFit project context
 
 This directory is the durable handoff for product and engineering context that would otherwise live only in long chat histories.
 
@@ -48,4 +48,4 @@ Do not silently promote a provisional idea into an irreversible contract.
 
 ## Why this exists
 
-Keylornet was designed through a long product/architecture discussion covering workout logging, exercise taxonomy, rankings, groups, social features, privacy, offline behavior, analytics, infrastructure and delivery strategy. The important ideas must survive model/session changes and should not depend on anyone remembering a previous conversation.
+KeylorFit was designed through a long product/architecture discussion covering workout logging, exercise taxonomy, rankings, groups, social features, privacy, offline behavior, analytics, infrastructure and delivery strategy. The important ideas must survive model/session changes and should not depend on anyone remembering a previous conversation.

--- a/docs/project-context/TECHNICAL_BLUEPRINT.md
+++ b/docs/project-context/TECHNICAL_BLUEPRINT.md
@@ -1,4 +1,4 @@
-# Keylornet technical blueprint
+# KeylorFit technical blueprint
 
 This document summarizes the technical direction and rationale established during the original design work. Accepted ADRs remain authoritative where they exist.
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,6 +1,6 @@
-# Keylornet API
+# KeylorFit API
 
-Minimal FastAPI foundation for the Keylornet modular monolith. It deliberately
+Minimal FastAPI foundation for the KeylorFit modular monolith. It deliberately
 contains no authentication, persistence, migrations, or product-domain APIs.
 
 ## Requirements

--- a/services/api/app/__init__.py
+++ b/services/api/app/__init__.py
@@ -1,1 +1,1 @@
-"""Keylornet API application package."""
+"""KeylorFit API application package."""

--- a/services/api/app/identity/schemas.py
+++ b/services/api/app/identity/schemas.py
@@ -14,7 +14,7 @@ class ProfileFoundationResponse(BaseModel):
 
 
 class MeResponse(BaseModel):
-    """The active caller's own Keylornet identity and profile foundation."""
+    """The active caller's own KeylorFit identity and profile foundation."""
 
     id: UUID
     profile: ProfileFoundationResponse

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "keylornet-api"
 version = "0.1.0"
-description = "Keylornet FastAPI backend foundation"
+description = "KeylorFit FastAPI backend foundation"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [


### PR DESCRIPTION
Closes #52

## Summary
Rename the current product identity from Keylornet to KeylorFit without renaming the repository or stable technical namespaces.

## Changes
- Set the Expo app name, slug, and custom scheme to `KeylorFit` / `keylorfit` / `keylorfit`.
- Set the stable Android application id to `com.jonathansalgadonieto.keylorfit`.
- Update current mobile copy, package metadata, README/runbook, product context, and M1 contracts.
- Define `keylorfit://auth/confirm` and `keylorfit://auth/recovery` as the callback contract.
- Retain `KEYLORNET_*`, database/volume names, Python package names, imports, and repository identity where intentionally internal/historical.
- Document the Supabase Auth transition and its boundary with #49/#41.

## Validation
- Local mobile install/lint/typecheck/tests passed during implementation; tests: 5 suites / 21 tests.
- Required GitHub Actions on current HEAD `ef7675a4cea2edb97c2c6eae45bb729e83920aa4` all pass: Backend CI, Mobile CI, Database Migration CI.
- Manual Supabase read-back completed on 2026-08-30: exact `keylorfit://auth/confirm` and `keylorfit://auth/recovery` callbacks are present, legacy callbacks are temporarily retained, and no wildcard redirect is configured.
- Physical Android development-build smoke completed on 2026-08-30: the app launches as KeylorFit and Android resolves both `keylorfit://auth/confirm` and `keylorfit://auth/recovery` to the app.
- Email-template branding is not editable on this newly created Free project while using Supabase default SMTP; #52 explicitly scopes that requirement to where the hosted template supports it, so this is non-blocking. A future custom-SMTP task can own branded production delivery.

## Boundaries
- This PR does not implement `emailRedirectTo`, confirmation-link consumption, recovery-link handling, or the localhost/null defect; those remain #49/#41.
- Site URL may remain `http://localhost:3000` for now because #49 owns explicit confirmation redirect selection.
- Legacy `keylornet://` callbacks remain only for the controlled installed-build transition and can be removed once no accepted build depends on them.

## Rollback
Revert the BRAND-001 commits and retain the legacy callback allow-list entries until the previous development build is confirmed operational.