### PR TITLE
fix(auth): harden JWKS refresh failures

### DIFF
--- a/services/api/app/auth/dependencies.py
+++ b/services/api/app/auth/dependencies.py
@@ -17,6 +17,7 @@ from app.auth.jwt_verifier import (
     AuthenticationError,
     AuthorizationError,
     JwksCache,
+    JwksProviderUnavailableError,
     SupabaseJwtVerifier,
 )
 from app.config import Settings
@@ -63,6 +64,11 @@ def get_authenticated_principal(
         )
     try:
         return get_jwt_verifier(request).verify(credentials.credentials)
+    except JwksProviderUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="authentication is temporarily unavailable",
+        ) from exc
     except AuthenticationError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/services/api/app/auth/jwt_verifier.py
+++ b/services/api/app/auth/jwt_verifier.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 import jwt
 from jwt import InvalidSignatureError, PyJWKSet
-from jwt.exceptions import InvalidTokenError, PyJWKSetError
+from jwt.exceptions import InvalidTokenError
 
 
 class AuthenticationError(Exception):
@@ -67,13 +67,14 @@ class JwksCache:
         self._generation = 0
         self._unknown_key_refresh_generation: int | None = None
         self._unknown_key_discovery_in_flight = False
-        self._unknown_key_failure_until = 0.0
-        self._unknown_key_failure: JwksProviderUnavailableError | None = None
         self._signature_refresh_generation_by_key: dict[str, int] = {}
+        self._signature_refresh_in_flight: set[tuple[str, int]] = set()
         self._lock = RLock()
         self._refresh_condition = Condition(self._lock)
         self._refreshing = False
         self._last_refresh_error: JwksProviderUnavailableError | None = None
+        self._provider_failure_until = 0.0
+        self._provider_failure: JwksProviderUnavailableError | None = None
 
     def get_key(self, key_id: str, *, refresh: bool = False) -> Any:
         """Return a trusted public key, refreshing once for an unknown key ID."""
@@ -85,27 +86,26 @@ class JwksCache:
     ) -> tuple[Any, int]:
         """Return a trusted key and cache generation for signature-failure recovery."""
         forced_refresh_pending = refresh
-        cold_lookup_pending = False
         while True:
+            discovery_refresh = False
+            lookup_requires_refresh = False
             with self._lock:
                 key = self._keys.get(key_id)
                 cache_expired = monotonic() >= self._expires_at
                 if key is not None and not forced_refresh_pending and not cache_expired:
                     return key, self._generation
 
-                discovery_refresh = False
                 if forced_refresh_pending or cache_expired:
-                    cold_lookup_pending = key is None and self._generation == 0
-                    discovery_refresh = key is None and not cold_lookup_pending
+                    lookup_requires_refresh = key is None
                     forced_refresh_pending = False
                 elif key is None:
-                    if (
-                        self._unknown_key_failure is not None
-                        and monotonic() < self._unknown_key_failure_until
-                    ):
-                        raise self._unknown_key_failure
+                    self._raise_if_provider_backing_off()
                     if self._unknown_key_discovery_in_flight:
-                        self._refresh_condition.wait_for(lambda: not self._refreshing)
+                        self._refresh_condition.wait_for(
+                            lambda: not self._unknown_key_discovery_in_flight
+                        )
+                        if self._last_refresh_error is not None:
+                            raise self._last_refresh_error
                         continue
                     if self._unknown_key_refresh_generation == self._generation:
                         raise AuthenticationError("untrusted signing key")
@@ -113,14 +113,28 @@ class JwksCache:
                     # cache generation, rather than one provider request per
                     # forged key identifier.
                     discovery_refresh = True
+                    self._unknown_key_refresh_generation = self._generation
+                    self._unknown_key_discovery_in_flight = True
 
-            self._refresh(discovery=discovery_refresh)
-            if cold_lookup_pending:
+            try:
+                self._refresh()
+            except JwksProviderUnavailableError:
+                if discovery_refresh:
+                    with self._lock:
+                        self._unknown_key_discovery_in_flight = False
+                        self._unknown_key_refresh_generation = None
+                        self._refresh_condition.notify_all()
+                raise
+            if discovery_refresh:
+                with self._lock:
+                    self._unknown_key_discovery_in_flight = False
+                    self._unknown_key_refresh_generation = self._generation
+                    self._refresh_condition.notify_all()
+            if lookup_requires_refresh:
                 with self._lock:
                     if self._keys.get(key_id) is None:
                         self._unknown_key_refresh_generation = self._generation
                         raise AuthenticationError("untrusted signing key")
-                cold_lookup_pending = False
 
     def refresh_key_after_signature_failure(
         self, key_id: str, observed_generation: int
@@ -132,30 +146,45 @@ class JwksCache:
         invalid tokens against that refreshed generation fail closed without
         repeatedly fetching the configured JWKS endpoint.
         """
-        with self._lock:
-            if self._generation != observed_generation:
-                return self._keys.get(key_id)
-            if (
-                self._signature_refresh_generation_by_key.get(key_id)
-                == self._generation
-            ):
-                return None
-
-            self._signature_refresh_generation_by_key[key_id] = self._generation
-
-        try:
-            self._refresh()
-        except JwksProviderUnavailableError:
+        refresh_key = (key_id, observed_generation)
+        while True:
             with self._lock:
-                self._signature_refresh_generation_by_key.pop(key_id, None)
-            raise
-        with self._lock:
-            self._signature_refresh_generation_by_key[key_id] = self._generation
-            return self._keys.get(key_id)
+                if self._generation != observed_generation:
+                    return self._keys.get(key_id)
+                self._raise_if_provider_backing_off()
+                if refresh_key in self._signature_refresh_in_flight:
+                    self._refresh_condition.wait_for(
+                        lambda: refresh_key not in self._signature_refresh_in_flight
+                    )
+                    if self._last_refresh_error is not None:
+                        raise self._last_refresh_error
+                    continue
+                if (
+                    self._signature_refresh_generation_by_key.get(key_id)
+                    == self._generation
+                ):
+                    return None
+                self._signature_refresh_generation_by_key[key_id] = self._generation
+                self._signature_refresh_in_flight.add(refresh_key)
 
-    def _refresh(self, *, discovery: bool = False) -> None:
+            try:
+                self._refresh()
+            except JwksProviderUnavailableError:
+                with self._lock:
+                    self._signature_refresh_in_flight.discard(refresh_key)
+                    self._signature_refresh_generation_by_key.pop(key_id, None)
+                    self._refresh_condition.notify_all()
+                raise
+            with self._lock:
+                self._signature_refresh_in_flight.discard(refresh_key)
+                self._signature_refresh_generation_by_key[key_id] = self._generation
+                self._refresh_condition.notify_all()
+                return self._keys.get(key_id)
+
+    def _refresh(self) -> None:
         """Refresh once at a time without holding the cache lock during I/O."""
         with self._lock:
+            self._raise_if_provider_backing_off()
             if self._refreshing:
                 self._refresh_condition.wait_for(lambda: not self._refreshing)
                 if self._last_refresh_error is not None:
@@ -163,8 +192,6 @@ class JwksCache:
                 return
             self._refreshing = True
             self._last_refresh_error = None
-            if discovery:
-                self._unknown_key_discovery_in_flight = True
 
         try:
             jwk_set = PyJWKSet.from_dict(dict(self._fetcher(self._jwks_url)))
@@ -173,31 +200,38 @@ class JwksCache:
                 for key in jwk_set.keys
                 if key.key_id is not None and key.key is not None
             }
-        except (OSError, PyJWKSetError, TypeError, ValueError) as exc:
+        except Exception as exc:
             unavailable = JwksProviderUnavailableError("JWKS provider is unavailable")
             with self._lock:
                 self._last_refresh_error = unavailable
-                if discovery:
-                    self._unknown_key_discovery_in_flight = False
-                    self._unknown_key_failure = unavailable
-                    self._unknown_key_failure_until = (
-                        monotonic() + self._failure_backoff_seconds
-                    )
+                self._provider_failure = unavailable
+                self._provider_failure_until = (
+                    monotonic() + self._failure_backoff_seconds
+                )
                 self._refreshing = False
                 self._refresh_condition.notify_all()
             raise unavailable from exc
+        except BaseException:
+            with self._lock:
+                self._refreshing = False
+                self._refresh_condition.notify_all()
+            raise
 
         with self._lock:
             self._keys = keys
             self._expires_at = monotonic() + self._cache_seconds
             self._generation += 1
-            self._unknown_key_failure = None
-            self._unknown_key_failure_until = 0.0
-            if discovery:
-                self._unknown_key_refresh_generation = self._generation
-                self._unknown_key_discovery_in_flight = False
+            self._provider_failure = None
+            self._provider_failure_until = 0.0
             self._refreshing = False
             self._refresh_condition.notify_all()
+
+    def _raise_if_provider_backing_off(self) -> None:
+        if (
+            self._provider_failure is not None
+            and monotonic() < self._provider_failure_until
+        ):
+            raise self._provider_failure
 
 
 class SupabaseJwtVerifier:

--- a/services/api/app/auth/jwt_verifier.py
+++ b/services/api/app/auth/jwt_verifier.py
@@ -56,14 +56,19 @@ class JwksCache:
         jwks_url: str,
         cache_seconds: int,
         fetcher: JwksFetcher = _fetch_jwks,
+        failure_backoff_seconds: int = 5,
     ) -> None:
         self._jwks_url = jwks_url
         self._cache_seconds = cache_seconds
         self._fetcher = fetcher
+        self._failure_backoff_seconds = failure_backoff_seconds
         self._keys: dict[str, Any] = {}
         self._expires_at = 0.0
         self._generation = 0
         self._unknown_key_refresh_generation: int | None = None
+        self._unknown_key_discovery_in_flight = False
+        self._unknown_key_failure_until = 0.0
+        self._unknown_key_failure: JwksProviderUnavailableError | None = None
         self._signature_refresh_generation_by_key: dict[str, int] = {}
         self._lock = RLock()
         self._refresh_condition = Condition(self._lock)
@@ -80,7 +85,7 @@ class JwksCache:
     ) -> tuple[Any, int]:
         """Return a trusted key and cache generation for signature-failure recovery."""
         forced_refresh_pending = refresh
-        refreshed_for_lookup = False
+        cold_lookup_pending = False
         while True:
             with self._lock:
                 key = self._keys.get(key_id)
@@ -88,24 +93,34 @@ class JwksCache:
                 if key is not None and not forced_refresh_pending and not cache_expired:
                     return key, self._generation
 
+                discovery_refresh = False
                 if forced_refresh_pending or cache_expired:
+                    cold_lookup_pending = key is None and self._generation == 0
+                    discovery_refresh = key is None and not cold_lookup_pending
                     forced_refresh_pending = False
-                elif refreshed_for_lookup:
-                    self._unknown_key_refresh_generation = self._generation
-                    raise AuthenticationError("untrusted signing key")
-                elif self._unknown_key_refresh_generation == self._generation:
-                    if self._refreshing:
+                elif key is None:
+                    if (
+                        self._unknown_key_failure is not None
+                        and monotonic() < self._unknown_key_failure_until
+                    ):
+                        raise self._unknown_key_failure
+                    if self._unknown_key_discovery_in_flight:
                         self._refresh_condition.wait_for(lambda: not self._refreshing)
                         continue
-                    raise AuthenticationError("untrusted signing key")
-                else:
+                    if self._unknown_key_refresh_generation == self._generation:
+                        raise AuthenticationError("untrusted signing key")
                     # Bound unknown-key discovery to one refresh for the entire
                     # cache generation, rather than one provider request per
                     # forged key identifier.
-                    self._unknown_key_refresh_generation = self._generation
+                    discovery_refresh = True
 
-            self._refresh()
-            refreshed_for_lookup = True
+            self._refresh(discovery=discovery_refresh)
+            if cold_lookup_pending:
+                with self._lock:
+                    if self._keys.get(key_id) is None:
+                        self._unknown_key_refresh_generation = self._generation
+                        raise AuthenticationError("untrusted signing key")
+                cold_lookup_pending = False
 
     def refresh_key_after_signature_failure(
         self, key_id: str, observed_generation: int
@@ -138,7 +153,7 @@ class JwksCache:
             self._signature_refresh_generation_by_key[key_id] = self._generation
             return self._keys.get(key_id)
 
-    def _refresh(self) -> None:
+    def _refresh(self, *, discovery: bool = False) -> None:
         """Refresh once at a time without holding the cache lock during I/O."""
         with self._lock:
             if self._refreshing:
@@ -148,6 +163,8 @@ class JwksCache:
                 return
             self._refreshing = True
             self._last_refresh_error = None
+            if discovery:
+                self._unknown_key_discovery_in_flight = True
 
         try:
             jwk_set = PyJWKSet.from_dict(dict(self._fetcher(self._jwks_url)))
@@ -160,7 +177,12 @@ class JwksCache:
             unavailable = JwksProviderUnavailableError("JWKS provider is unavailable")
             with self._lock:
                 self._last_refresh_error = unavailable
-                self._unknown_key_refresh_generation = None
+                if discovery:
+                    self._unknown_key_discovery_in_flight = False
+                    self._unknown_key_failure = unavailable
+                    self._unknown_key_failure_until = (
+                        monotonic() + self._failure_backoff_seconds
+                    )
                 self._refreshing = False
                 self._refresh_condition.notify_all()
             raise unavailable from exc
@@ -169,7 +191,11 @@ class JwksCache:
             self._keys = keys
             self._expires_at = monotonic() + self._cache_seconds
             self._generation += 1
-            self._unknown_key_refresh_generation = None
+            self._unknown_key_failure = None
+            self._unknown_key_failure_until = 0.0
+            if discovery:
+                self._unknown_key_refresh_generation = self._generation
+                self._unknown_key_discovery_in_flight = False
             self._refreshing = False
             self._refresh_condition.notify_all()
 

--- a/services/api/app/auth/jwt_verifier.py
+++ b/services/api/app/auth/jwt_verifier.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from threading import RLock
+from threading import Condition, RLock
 from time import monotonic
 from typing import Any
 from urllib.request import Request, urlopen
@@ -13,7 +13,7 @@ from uuid import UUID
 
 import jwt
 from jwt import InvalidSignatureError, PyJWKSet
-from jwt.exceptions import InvalidTokenError
+from jwt.exceptions import InvalidTokenError, PyJWKSetError
 
 
 class AuthenticationError(Exception):
@@ -22,6 +22,10 @@ class AuthenticationError(Exception):
 
 class AuthorizationError(Exception):
     """Raised when a valid token is not permitted to use a protected route."""
+
+
+class JwksProviderUnavailableError(Exception):
+    """Raised when the configured JWKS provider cannot be reached or decoded."""
 
 
 @dataclass(frozen=True)
@@ -59,8 +63,12 @@ class JwksCache:
         self._keys: dict[str, Any] = {}
         self._expires_at = 0.0
         self._generation = 0
+        self._unknown_key_refresh_generation: int | None = None
         self._signature_refresh_generation_by_key: dict[str, int] = {}
         self._lock = RLock()
+        self._refresh_condition = Condition(self._lock)
+        self._refreshing = False
+        self._last_refresh_error: JwksProviderUnavailableError | None = None
 
     def get_key(self, key_id: str, *, refresh: bool = False) -> Any:
         """Return a trusted public key, refreshing once for an unknown key ID."""
@@ -71,16 +79,33 @@ class JwksCache:
         self, key_id: str, *, refresh: bool = False
     ) -> tuple[Any, int]:
         """Return a trusted key and cache generation for signature-failure recovery."""
-        with self._lock:
-            if refresh or monotonic() >= self._expires_at:
-                self._refresh()
-            key = self._keys.get(key_id)
-            if key is None and not refresh:
-                self._refresh()
+        forced_refresh_pending = refresh
+        refreshed_for_lookup = False
+        while True:
+            with self._lock:
                 key = self._keys.get(key_id)
-            if key is None:
-                raise AuthenticationError("untrusted signing key")
-            return key, self._generation
+                cache_expired = monotonic() >= self._expires_at
+                if key is not None and not forced_refresh_pending and not cache_expired:
+                    return key, self._generation
+
+                if forced_refresh_pending or cache_expired:
+                    forced_refresh_pending = False
+                elif refreshed_for_lookup:
+                    self._unknown_key_refresh_generation = self._generation
+                    raise AuthenticationError("untrusted signing key")
+                elif self._unknown_key_refresh_generation == self._generation:
+                    if self._refreshing:
+                        self._refresh_condition.wait_for(lambda: not self._refreshing)
+                        continue
+                    raise AuthenticationError("untrusted signing key")
+                else:
+                    # Bound unknown-key discovery to one refresh for the entire
+                    # cache generation, rather than one provider request per
+                    # forged key identifier.
+                    self._unknown_key_refresh_generation = self._generation
+
+            self._refresh()
+            refreshed_for_lookup = True
 
     def refresh_key_after_signature_failure(
         self, key_id: str, observed_generation: int
@@ -88,7 +113,7 @@ class JwksCache:
         """Refresh a known key at most once per cache generation.
 
         A failed signature may indicate a provider key rotation that reused a
-        key identifier.  The first failure refreshes under the cache lock; later
+        key identifier. The first failure coordinates one refresh; later
         invalid tokens against that refreshed generation fail closed without
         repeatedly fetching the configured JWKS endpoint.
         """
@@ -101,19 +126,52 @@ class JwksCache:
             ):
                 return None
 
+            self._signature_refresh_generation_by_key[key_id] = self._generation
+
+        try:
             self._refresh()
+        except JwksProviderUnavailableError:
+            with self._lock:
+                self._signature_refresh_generation_by_key.pop(key_id, None)
+            raise
+        with self._lock:
             self._signature_refresh_generation_by_key[key_id] = self._generation
             return self._keys.get(key_id)
 
     def _refresh(self) -> None:
-        jwk_set = PyJWKSet.from_dict(dict(self._fetcher(self._jwks_url)))
-        self._keys = {
-            key.key_id: key.key
-            for key in jwk_set.keys
-            if key.key_id is not None and key.key is not None
-        }
-        self._expires_at = monotonic() + self._cache_seconds
-        self._generation += 1
+        """Refresh once at a time without holding the cache lock during I/O."""
+        with self._lock:
+            if self._refreshing:
+                self._refresh_condition.wait_for(lambda: not self._refreshing)
+                if self._last_refresh_error is not None:
+                    raise self._last_refresh_error
+                return
+            self._refreshing = True
+            self._last_refresh_error = None
+
+        try:
+            jwk_set = PyJWKSet.from_dict(dict(self._fetcher(self._jwks_url)))
+            keys = {
+                key.key_id: key.key
+                for key in jwk_set.keys
+                if key.key_id is not None and key.key is not None
+            }
+        except (OSError, PyJWKSetError, TypeError, ValueError) as exc:
+            unavailable = JwksProviderUnavailableError("JWKS provider is unavailable")
+            with self._lock:
+                self._last_refresh_error = unavailable
+                self._unknown_key_refresh_generation = None
+                self._refreshing = False
+                self._refresh_condition.notify_all()
+            raise unavailable from exc
+
+        with self._lock:
+            self._keys = keys
+            self._expires_at = monotonic() + self._cache_seconds
+            self._generation += 1
+            self._unknown_key_refresh_generation = None
+            self._refreshing = False
+            self._refresh_condition.notify_all()
 
 
 class SupabaseJwtVerifier:
@@ -152,12 +210,11 @@ class SupabaseJwtVerifier:
             if not isinstance(subject, str):
                 raise AuthenticationError("missing token subject")
             return AuthenticatedPrincipal(external_subject=UUID(subject))
-        except AuthorizationError:
+        except (AuthorizationError, JwksProviderUnavailableError):
             raise
         except (
             AuthenticationError,
             InvalidTokenError,
-            OSError,
             TypeError,
             ValueError,
         ) as exc:

--- a/services/api/tests/test_identity.py
+++ b/services/api/tests/test_identity.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi.testclient import TestClient
 
 from app.auth.dependencies import get_database_session
-from app.auth.jwt_verifier import AuthenticatedPrincipal
+from app.auth.jwt_verifier import AuthenticatedPrincipal, JwksProviderUnavailableError
 from app.config import Settings
 from app.identity import router as identity_router
 from app.identity.schemas import MeResponse, ProfileFoundationResponse
@@ -20,6 +20,11 @@ class _Verifier:
     def verify(self, token: str) -> AuthenticatedPrincipal:
         assert token == "valid-token"
         return self._principal
+
+
+class _UnavailableVerifier:
+    def verify(self, token: str) -> AuthenticatedPrincipal:
+        raise JwksProviderUnavailableError("provider timed out")
 
 
 def test_me_rejects_a_missing_bearer_token() -> None:
@@ -38,6 +43,17 @@ def test_me_rejects_a_malformed_bearer_header() -> None:
 
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_me_reports_jwks_provider_outage_as_retryable() -> None:
+    app = create_app(Settings(supabase_project_url="https://example.supabase.co"))
+    app.state.jwt_verifier = _UnavailableVerifier()
+    client = TestClient(app)
+
+    response = client.get("/me", headers={"Authorization": "Bearer valid-token"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "authentication is temporarily unavailable"}
 
 
 def test_me_uses_the_authenticated_principal_not_a_client_identifier(

--- a/services/api/tests/test_jwt_verifier.py
+++ b/services/api/tests/test_jwt_verifier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from http.client import IncompleteRead
 from threading import Event, Thread
 from uuid import uuid4
 
@@ -270,6 +271,32 @@ def test_provider_outage_is_distinct_from_invalid_credentials() -> None:
         verifier.verify(_token(private_key, key_id="trusted"))
 
 
+def test_bounds_cold_cache_provider_failures_with_backoff() -> None:
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        raise TimeoutError("provider timed out")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache(
+            "https://example.invalid/jwks",
+            300,
+            fetcher=fetcher,
+            failure_backoff_seconds=60,
+        ),
+    )
+
+    for key_id in ("forged-one", "forged-two", "forged-three"):
+        with pytest.raises(JwksProviderUnavailableError):
+            verifier.verify(_token(attacker_key, key_id=key_id))
+
+    assert fetch_count == 1
+
+
 def test_bounds_unknown_key_provider_failures_with_backoff() -> None:
     trusted_key = ec.generate_private_key(ec.SECP256R1())
     attacker_key = ec.generate_private_key(ec.SECP256R1())
@@ -296,6 +323,93 @@ def test_bounds_unknown_key_provider_failures_with_backoff() -> None:
     for key_id in ("forged-one", "forged-two", "forged-three"):
         with pytest.raises(JwksProviderUnavailableError):
             verifier.verify(_token(attacker_key, key_id=key_id))
+
+    assert fetch_count == 2
+    verifier.verify(_token(trusted_key, key_id="trusted"))
+
+
+def test_bounds_signature_failure_provider_outages_with_backoff() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return _jwks(trusted_key, "stable-id")
+        raise TimeoutError("provider timed out")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache(
+            "https://example.invalid/jwks",
+            300,
+            fetcher=fetcher,
+            failure_backoff_seconds=60,
+        ),
+    )
+    invalid_token = _token(attacker_key, key_id="stable-id")
+    verifier.verify(_token(trusted_key, key_id="stable-id"))
+
+    for _ in range(3):
+        with pytest.raises(JwksProviderUnavailableError):
+            verifier.verify(invalid_token)
+
+    assert fetch_count == 2
+
+
+def test_refresh_state_recovers_from_unexpected_provider_exception() -> None:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        raise IncompleteRead(b"", 1)
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache(
+            "https://example.invalid/jwks",
+            300,
+            fetcher=fetcher,
+            failure_backoff_seconds=60,
+        ),
+    )
+
+    for _ in range(2):
+        with pytest.raises(JwksProviderUnavailableError):
+            verifier.verify(_token(private_key, key_id="trusted"))
+
+    assert fetch_count == 1
+
+
+def test_bounds_expired_cache_provider_failures_with_backoff() -> None:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return _jwks(private_key, "active-key")
+        raise TimeoutError("provider timed out")
+
+    cache = JwksCache(
+        "https://example.invalid/jwks",
+        300,
+        fetcher=fetcher,
+        failure_backoff_seconds=60,
+    )
+    verifier = SupabaseJwtVerifier(issuer=ISSUER, jwks=cache)
+    token = _token(private_key, key_id="active-key")
+    verifier.verify(token)
+    cache._expires_at = 0.0
+
+    for _ in range(3):
+        with pytest.raises(JwksProviderUnavailableError):
+            verifier.verify(token)
 
     assert fetch_count == 2
 
@@ -336,3 +450,128 @@ def test_rejects_bad_signature_without_repeated_jwks_refreshes() -> None:
         verifier.verify(invalid_token)
 
     assert fetch_count == 2
+
+
+def test_concurrent_signature_failures_share_a_same_key_rotation_refresh() -> None:
+    old_key = ec.generate_private_key(ec.SECP256R1())
+    rotated_key = ec.generate_private_key(ec.SECP256R1())
+    refresh_started = Event()
+    allow_refresh = Event()
+    fetch_count = 0
+    errors: list[Exception] = []
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return _jwks(old_key, "stable-id")
+        refresh_started.set()
+        assert allow_refresh.wait(timeout=1)
+        return _jwks(rotated_key, "stable-id")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher),
+    )
+    verifier.verify(_token(old_key, key_id="stable-id"))
+    rotated_token = _token(rotated_key, key_id="stable-id")
+
+    workers = [
+        Thread(
+            target=lambda: _record_verification_error(verifier, rotated_token, errors),
+            daemon=True,
+        )
+        for _ in range(3)
+    ]
+    workers[0].start()
+    assert refresh_started.wait(timeout=1)
+    for worker in workers[1:]:
+        worker.start()
+
+    allow_refresh.set()
+    for worker in workers:
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+
+    assert fetch_count == 2
+    assert errors == []
+
+
+def test_concurrent_signature_failures_share_provider_outage() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    refresh_started = Event()
+    allow_refresh = Event()
+    fetch_count = 0
+    errors: list[Exception] = []
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return _jwks(trusted_key, "stable-id")
+        refresh_started.set()
+        assert allow_refresh.wait(timeout=1)
+        raise TimeoutError("provider timed out")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache(
+            "https://example.invalid/jwks",
+            300,
+            fetcher=fetcher,
+            failure_backoff_seconds=60,
+        ),
+    )
+    verifier.verify(_token(trusted_key, key_id="stable-id"))
+    invalid_token = _token(attacker_key, key_id="stable-id")
+
+    workers = [
+        Thread(
+            target=lambda: _record_verification_error(verifier, invalid_token, errors),
+            daemon=True,
+        )
+        for _ in range(3)
+    ]
+    workers[0].start()
+    assert refresh_started.wait(timeout=1)
+    for worker in workers[1:]:
+        worker.start()
+
+    allow_refresh.set()
+    for worker in workers:
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+
+    assert fetch_count == 2
+    assert len(errors) == 3
+    assert all(isinstance(error, JwksProviderUnavailableError) for error in errors)
+
+
+def test_refreshes_expired_cache_entries() -> None:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        return _jwks(private_key, "active-key")
+
+    cache = JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher)
+    verifier = SupabaseJwtVerifier(issuer=ISSUER, jwks=cache)
+    token = _token(private_key, key_id="active-key")
+
+    verifier.verify(token)
+    cache._expires_at = 0.0
+    verifier.verify(token)
+
+    assert fetch_count == 2
+
+
+def _record_verification_error(
+    verifier: SupabaseJwtVerifier, token: str, errors: list[Exception]
+) -> None:
+    try:
+        verifier.verify(token)
+    except (AuthenticationError, JwksProviderUnavailableError) as exc:
+        errors.append(exc)

--- a/services/api/tests/test_jwt_verifier.py
+++ b/services/api/tests/test_jwt_verifier.py
@@ -188,11 +188,69 @@ def test_keeps_cached_keys_available_while_an_unknown_key_refreshes() -> None:
     assert not worker.is_alive()
 
 
+def test_concurrent_unknown_keys_share_one_discovery_refresh() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    refresh_started = Event()
+    allow_refresh = Event()
+    fetch_count = 0
+    errors: list[Exception] = []
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 2:
+            refresh_started.set()
+            assert allow_refresh.wait(timeout=1)
+        return _jwks(trusted_key, "trusted")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher),
+    )
+    verifier.verify(_token(trusted_key, key_id="trusted"))
+
+    workers = [
+        Thread(
+            target=lambda key_id=key_id: _record_unknown_key_error(
+                verifier, attacker_key, key_id, errors
+            ),
+            daemon=True,
+        )
+        for key_id in ("forged-one", "forged-two", "forged-three")
+    ]
+    workers[0].start()
+    assert refresh_started.wait(timeout=1)
+    for worker in workers[1:]:
+        worker.start()
+
+    allow_refresh.set()
+    for worker in workers:
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+
+    assert fetch_count == 2
+    assert len(errors) == 3
+    assert all(isinstance(error, AuthenticationError) for error in errors)
+
+
 def _verify_unknown_key(
     verifier: SupabaseJwtVerifier, attacker_key: ec.EllipticCurvePrivateKey
 ) -> None:
     with pytest.raises(AuthenticationError):
         verifier.verify(_token(attacker_key, key_id="forged"))
+
+
+def _record_unknown_key_error(
+    verifier: SupabaseJwtVerifier,
+    attacker_key: ec.EllipticCurvePrivateKey,
+    key_id: str,
+    errors: list[Exception],
+) -> None:
+    try:
+        verifier.verify(_token(attacker_key, key_id=key_id))
+    except AuthenticationError as exc:
+        errors.append(exc)
 
 
 def test_provider_outage_is_distinct_from_invalid_credentials() -> None:
@@ -210,6 +268,36 @@ def test_provider_outage_is_distinct_from_invalid_credentials() -> None:
 
     with pytest.raises(JwksProviderUnavailableError):
         verifier.verify(_token(private_key, key_id="trusted"))
+
+
+def test_bounds_unknown_key_provider_failures_with_backoff() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return _jwks(trusted_key, "trusted")
+        raise TimeoutError("provider timed out")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache(
+            "https://example.invalid/jwks",
+            300,
+            fetcher=fetcher,
+            failure_backoff_seconds=60,
+        ),
+    )
+    verifier.verify(_token(trusted_key, key_id="trusted"))
+
+    for key_id in ("forged-one", "forged-two", "forged-three"):
+        with pytest.raises(JwksProviderUnavailableError):
+            verifier.verify(_token(attacker_key, key_id=key_id))
+
+    assert fetch_count == 2
 
 
 def test_refreshes_jwks_when_a_key_rotates_with_the_same_id() -> None:

--- a/services/api/tests/test_jwt_verifier.py
+++ b/services/api/tests/test_jwt_verifier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from threading import Event, Thread
 from uuid import uuid4
 
 import jwt
@@ -14,6 +15,7 @@ from app.auth.jwt_verifier import (
     AuthenticationError,
     AuthorizationError,
     JwksCache,
+    JwksProviderUnavailableError,
     SupabaseJwtVerifier,
 )
 
@@ -104,9 +106,110 @@ def test_refreshes_jwks_when_unknown_key_id_appears() -> None:
         jwks=JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher),
     )
 
+    verifier.verify(_token(old_key, key_id="old"))
     verifier.verify(_token(new_key, key_id="new"))
 
     assert fetch_count == 2
+
+
+def test_bounds_unknown_key_refreshes_for_a_cache_generation() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        return _jwks(trusted_key, "trusted")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher),
+    )
+    verifier.verify(_token(trusted_key, key_id="trusted"))
+
+    for key_id in ("forged-one", "forged-two", "forged-one"):
+        with pytest.raises(AuthenticationError):
+            verifier.verify(_token(attacker_key, key_id=key_id))
+
+    assert fetch_count == 2
+
+
+def test_bounds_a_cold_unknown_key_to_one_provider_fetch() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        return _jwks(trusted_key, "trusted")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher),
+    )
+
+    with pytest.raises(AuthenticationError):
+        verifier.verify(_token(attacker_key, key_id="forged"))
+
+    assert fetch_count == 1
+
+
+def test_keeps_cached_keys_available_while_an_unknown_key_refreshes() -> None:
+    trusted_key = ec.generate_private_key(ec.SECP256R1())
+    attacker_key = ec.generate_private_key(ec.SECP256R1())
+    refresh_started = Event()
+    allow_refresh = Event()
+    fetch_count = 0
+
+    def fetcher(_: str) -> dict[str, object]:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 2:
+            refresh_started.set()
+            assert allow_refresh.wait(timeout=1)
+        return _jwks(trusted_key, "trusted")
+
+    cache = JwksCache("https://example.invalid/jwks", 300, fetcher=fetcher)
+    verifier = SupabaseJwtVerifier(issuer=ISSUER, jwks=cache)
+    verifier.verify(_token(trusted_key, key_id="trusted"))
+
+    worker = Thread(
+        target=lambda: _verify_unknown_key(verifier, attacker_key), daemon=True
+    )
+    worker.start()
+    assert refresh_started.wait(timeout=1)
+
+    assert cache.get_key("trusted") is not None
+
+    allow_refresh.set()
+    worker.join(timeout=1)
+    assert not worker.is_alive()
+
+
+def _verify_unknown_key(
+    verifier: SupabaseJwtVerifier, attacker_key: ec.EllipticCurvePrivateKey
+) -> None:
+    with pytest.raises(AuthenticationError):
+        verifier.verify(_token(attacker_key, key_id="forged"))
+
+
+def test_provider_outage_is_distinct_from_invalid_credentials() -> None:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+
+    def unavailable_fetcher(_: str) -> dict[str, object]:
+        raise TimeoutError("provider timed out")
+
+    verifier = SupabaseJwtVerifier(
+        issuer=ISSUER,
+        jwks=JwksCache(
+            "https://example.invalid/jwks", 300, fetcher=unavailable_fetcher
+        ),
+    )
+
+    with pytest.raises(JwksProviderUnavailableError):
+        verifier.verify(_token(private_key, key_id="trusted"))
 
 
 def test_refreshes_jwks_when_a_key_rotates_with_the_same_id() -> None:


### PR DESCRIPTION
## Summary

Harden Supabase JWKS refresh handling for unknown `kid` values, reused-key rotations, and provider outages.

## Changes

- Apply one global provider-failure backoff to every refresh-dependent path: cold cache, expiry, unknown-key discovery, and signature-failure recovery.
- Keep unexpired cached keys usable while provider backoff is active.
- Coordinate unknown-key discovery and same-`kid` signature-failure followers before network I/O; followers reuse the completed refresh or receive the same retryable provider failure.
- Make refresh cleanup exception-safe: all ordinary fetch/decode exceptions clear single-flight state, notify waiters, and become `JwksProviderUnavailableError` (HTTP 503).
- Add deterministic coverage for cold/expired/unknown/signature outage backoff, `IncompleteRead` recovery, same-`kid` concurrency, normal TTL refresh, and key rotation.

## Validation

- `.venv\Scripts\python.exe -m ruff format --check app tests` — passed.
- `.venv\Scripts\python.exe -m ruff check app tests` — passed.
- `.venv\Scripts\python.exe -m mypy app` — passed.
- `.venv\Scripts\python.exe -m pytest tests -q -p no:cacheprovider` — 31 passed.
- `.venv\Scripts\python.exe -m pip check` — passed.
- `git diff --check` — passed.

## Risks and assumptions

The five-second configured backoff is process-local and intentionally bounds provider I/O rather than treating a provider outage as invalid credentials. Tokens using unexpired cached keys continue to validate; refresh-dependent requests receive retryable HTTP 503. Invalid signatures and claims still fail closed with 401, while an authenticated but wrong role remains 403.

## Rollback

If this PR is merged, revert its resulting merge commit. Do not revert only an earlier branch commit such as `885da9c`, because the final behavior is at `b538559882d20e87bc9140d63d3cef5b868a26ec`.