### PR TITLE
feat(identity): add authenticated profile editing

### DIFF
--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Verify Alembic current head
         run: |
           python -m alembic current | tee alembic-current.txt
-          grep -Eq '^20260829_0001 \(head\)$' alembic-current.txt
+          grep -Eq '^20260831_0001 \(head\)$' alembic-current.txt
           python -m alembic heads

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,11 +1,17 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
+import { useState } from 'react';
 
 import { AuthProvider } from '@/lib/auth/auth-provider';
 
 export default function RootLayout() {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
-    <AuthProvider>
-      <Stack screenOptions={{ headerShown: false }} />
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <Stack screenOptions={{ headerShown: false }} />
+      </AuthProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'expo-router';
 import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -20,6 +21,9 @@ function HomeScreen() {
         Your training home
       </Text>
       <Text style={styles.message}>You are signed in to KeylorFit.</Text>
+      <Link accessibilityRole="link" href="/profile" style={styles.profileLink}>
+        Profile
+      </Link>
       {error ? (
         <Text accessibilityLiveRegion="polite" style={styles.error}>
           {error}
@@ -61,5 +65,11 @@ const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 24 },
   error: { color: '#b42318', marginTop: 12 },
   message: { color: '#4d5d74', fontSize: 16, marginTop: 12 },
+  profileLink: {
+    color: '#1d4f91',
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 24,
+  },
   title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
 });

--- a/apps/mobile/app/profile.tsx
+++ b/apps/mobile/app/profile.tsx
@@ -1,0 +1,10 @@
+import { RequireAuthenticated } from '@/components/auth/auth-guards';
+import { ProfileScreen } from '@/components/profile/profile-screen';
+
+export default function ProfileRoute() {
+  return (
+    <RequireAuthenticated>
+      <ProfileScreen />
+    </RequireAuthenticated>
+  );
+}

--- a/apps/mobile/components/profile/__tests__/profile-auth-failure.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-auth-failure.test.tsx
@@ -30,7 +30,7 @@ function authError() {
   );
 }
 
-function renderProfileScreen() {
+async function renderProfileScreen() {
   const queryClient = new QueryClient({
     defaultOptions: {
       mutations: { retry: false },
@@ -66,7 +66,7 @@ describe('ProfileScreen protected API authentication recovery', () => {
       .mockRejectedValueOnce(authError())
       .mockResolvedValueOnce(currentProfile);
 
-    const { findByDisplayValue } = renderProfileScreen();
+    const { findByDisplayValue } = await renderProfileScreen();
 
     expect(await findByDisplayValue('Taylor')).toBeTruthy();
     expect(refreshSession).toHaveBeenCalledTimes(1);
@@ -88,7 +88,7 @@ describe('ProfileScreen protected API authentication recovery', () => {
     } as unknown as ReturnType<typeof useAuth>);
     jest.mocked(getCurrentProfile).mockRejectedValue(authError());
 
-    renderProfileScreen();
+    await renderProfileScreen();
 
     await waitFor(() => {
       expect(invalidateSession).toHaveBeenCalledTimes(1);
@@ -112,7 +112,7 @@ describe('ProfileScreen protected API authentication recovery', () => {
     } as unknown as ReturnType<typeof useAuth>);
     jest.mocked(getCurrentProfile).mockRejectedValueOnce(authError());
 
-    const { findByText } = renderProfileScreen();
+    const { findByText } = await renderProfileScreen();
 
     expect(
       await findByText(
@@ -135,7 +135,7 @@ describe('ProfileScreen protected API authentication recovery', () => {
     } as unknown as ReturnType<typeof useAuth>);
     jest.mocked(getCurrentProfile).mockRejectedValueOnce(authError());
 
-    const { findByText } = renderProfileScreen();
+    const { findByText } = await renderProfileScreen();
 
     expect(
       await findByText('Your session has ended. Please sign in again.'),

--- a/apps/mobile/components/profile/__tests__/profile-auth-failure.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-auth-failure.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react-native';
 
 import { ProfileScreen } from '@/components/profile/profile-screen';
@@ -13,26 +14,133 @@ jest.mock('@/lib/profile/profile-api', () => ({
   getCurrentProfile: jest.fn(),
 }));
 
-describe('ProfileScreen terminal authentication failure', () => {
-  it('uses AuthProvider session invalidation after a 401 response', async () => {
+const currentProfile = {
+  id: 'b1f4d587-4eef-4af8-899b-b2173ee42de0',
+  profile: {
+    created_at: '2026-08-31T10:00:00Z',
+    display_name: 'Taylor',
+    updated_at: '2026-08-31T10:00:00Z',
+  },
+};
+
+function authError() {
+  return new ProfileApiError(
+    'auth',
+    'Your session has ended. Please sign in again.',
+  );
+}
+
+function renderProfileScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { gcTime: Infinity, retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProfileScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ProfileScreen protected API authentication recovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('refreshes once and retries a 401 before ending the session', async () => {
     const invalidateSession = jest.fn().mockResolvedValue(undefined);
+    const refreshSession = jest.fn().mockResolvedValue('fresh-token');
     jest.mocked(useAuth).mockReturnValue({
       invalidateSession,
-      session: { access_token: 'current-token' },
+      refreshSession,
+      session: {
+        access_token: 'expired-token',
+        user: { id: 'user-1' },
+      },
     } as unknown as ReturnType<typeof useAuth>);
     jest
       .mocked(getCurrentProfile)
-      .mockRejectedValue(
-        new ProfileApiError(
-          'auth',
-          'Your session has ended. Please sign in again.',
-        ),
-      );
+      .mockRejectedValueOnce(authError())
+      .mockResolvedValueOnce(currentProfile);
 
-    await render(<ProfileScreen />);
+    const { findByDisplayValue } = renderProfileScreen();
+
+    expect(await findByDisplayValue('Taylor')).toBeTruthy();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(getCurrentProfile).toHaveBeenNthCalledWith(1, 'expired-token');
+    expect(getCurrentProfile).toHaveBeenNthCalledWith(2, 'fresh-token');
+    expect(invalidateSession).not.toHaveBeenCalled();
+  });
+
+  it('invalidates locally only when the refreshed token is also rejected', async () => {
+    const invalidateSession = jest.fn().mockResolvedValue(undefined);
+    const refreshSession = jest.fn().mockResolvedValue('fresh-token');
+    jest.mocked(useAuth).mockReturnValue({
+      invalidateSession,
+      refreshSession,
+      session: {
+        access_token: 'expired-token',
+        user: { id: 'user-1' },
+      },
+    } as unknown as ReturnType<typeof useAuth>);
+    jest.mocked(getCurrentProfile).mockRejectedValue(authError());
+
+    renderProfileScreen();
 
     await waitFor(() => {
       expect(invalidateSession).toHaveBeenCalledTimes(1);
     });
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(getCurrentProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the current session on a transient refresh failure', async () => {
+    const invalidateSession = jest.fn().mockResolvedValue(undefined);
+    const refreshSession = jest
+      .fn()
+      .mockRejectedValue(new Error('network unavailable'));
+    jest.mocked(useAuth).mockReturnValue({
+      invalidateSession,
+      refreshSession,
+      session: {
+        access_token: 'expired-token',
+        user: { id: 'user-1' },
+      },
+    } as unknown as ReturnType<typeof useAuth>);
+    jest.mocked(getCurrentProfile).mockRejectedValueOnce(authError());
+
+    const { findByText } = renderProfileScreen();
+
+    expect(
+      await findByText(
+        'We could not refresh your session. Check your connection and try again.',
+      ),
+    ).toBeTruthy();
+    expect(invalidateSession).not.toHaveBeenCalled();
+  });
+
+  it('does not double-invalidate when refreshSession already ends a terminal session', async () => {
+    const invalidateSession = jest.fn().mockResolvedValue(undefined);
+    const refreshSession = jest.fn().mockResolvedValue(null);
+    jest.mocked(useAuth).mockReturnValue({
+      invalidateSession,
+      refreshSession,
+      session: {
+        access_token: 'expired-token',
+        user: { id: 'user-1' },
+      },
+    } as unknown as ReturnType<typeof useAuth>);
+    jest.mocked(getCurrentProfile).mockRejectedValueOnce(authError());
+
+    const { findByText } = renderProfileScreen();
+
+    expect(
+      await findByText('Your session has ended. Please sign in again.'),
+    ).toBeTruthy();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(invalidateSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/components/profile/__tests__/profile-auth-failure.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-auth-failure.test.tsx
@@ -1,0 +1,38 @@
+import { render, waitFor } from '@testing-library/react-native';
+
+import { ProfileScreen } from '@/components/profile/profile-screen';
+import { useAuth } from '@/lib/auth/auth-provider';
+import { getCurrentProfile, ProfileApiError } from '@/lib/profile/profile-api';
+
+jest.mock('@/lib/auth/auth-provider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/profile/profile-api', () => ({
+  ...jest.requireActual('@/lib/profile/profile-api'),
+  getCurrentProfile: jest.fn(),
+}));
+
+describe('ProfileScreen terminal authentication failure', () => {
+  it('uses AuthProvider session invalidation after a 401 response', async () => {
+    const invalidateSession = jest.fn().mockResolvedValue(undefined);
+    jest.mocked(useAuth).mockReturnValue({
+      invalidateSession,
+      session: { access_token: 'current-token' },
+    } as unknown as ReturnType<typeof useAuth>);
+    jest
+      .mocked(getCurrentProfile)
+      .mockRejectedValue(
+        new ProfileApiError(
+          'auth',
+          'Your session has ended. Please sign in again.',
+        ),
+      );
+
+    await render(<ProfileScreen />);
+
+    await waitFor(() => {
+      expect(invalidateSession).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
@@ -36,14 +36,14 @@ function createTestQueryClient() {
   });
 }
 
-function renderProfileScreen() {
+async function renderProfileScreen() {
   const queryClient = createTestQueryClient();
   const ui = () => (
     <QueryClientProvider client={queryClient}>
       <ProfileScreen />
     </QueryClientProvider>
   );
-  const result = render(ui());
+  const result = await render(ui());
 
   return {
     ...result,
@@ -72,7 +72,7 @@ describe('ProfileScreen', () => {
   it('loads the server-backed display name using the current access token', async () => {
     jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
 
-    const { findByDisplayValue } = renderProfileScreen();
+    const { findByDisplayValue } = await renderProfileScreen();
 
     expect(await findByDisplayValue('Taylor')).toBeTruthy();
     expect(getCurrentProfile).toHaveBeenCalledWith('current-token');
@@ -84,7 +84,7 @@ describe('ProfileScreen', () => {
       ...profile('Jordan Server').profile,
     });
     const { findByDisplayValue, findByText, getByLabelText, getByText } =
-      renderProfileScreen();
+      await renderProfileScreen();
 
     await findByDisplayValue('Taylor');
     await act(async () => {
@@ -106,7 +106,7 @@ describe('ProfileScreen', () => {
   it('preserves dirty input when the access token rotates or cached server data refreshes', async () => {
     jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
     const { getByLabelText, getByDisplayValue, queryClient, rerenderProfile } =
-      renderProfileScreen();
+      await renderProfileScreen();
 
     await waitFor(() => {
       expect(getByDisplayValue('Taylor')).toBeTruthy();
@@ -116,7 +116,7 @@ describe('ProfileScreen', () => {
     });
 
     jest.mocked(useAuth).mockReturnValue(authValue('refreshed-access-token'));
-    rerenderProfile();
+    await rerenderProfile();
 
     await act(async () => {
       queryClient.setQueryData(

--- a/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
@@ -1,13 +1,5 @@
-import {
-  QueryClient,
-  QueryClientProvider,
-} from '@tanstack/react-query';
-import {
-  act,
-  fireEvent,
-  render,
-  waitFor,
-} from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import { ProfileScreen } from '@/components/profile/profile-screen';
 import { useAuth } from '@/lib/auth/auth-provider';
@@ -113,12 +105,8 @@ describe('ProfileScreen', () => {
 
   it('preserves dirty input when the access token rotates or cached server data refreshes', async () => {
     jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
-    const {
-      getByLabelText,
-      getByDisplayValue,
-      queryClient,
-      rerenderProfile,
-    } = renderProfileScreen();
+    const { getByLabelText, getByDisplayValue, queryClient, rerenderProfile } =
+      renderProfileScreen();
 
     await waitFor(() => {
       expect(getByDisplayValue('Taylor')).toBeTruthy();

--- a/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
@@ -1,4 +1,13 @@
-import { act, fireEvent, render } from '@testing-library/react-native';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react-native';
 
 import { ProfileScreen } from '@/components/profile/profile-screen';
 import { useAuth } from '@/lib/auth/auth-provider';
@@ -26,36 +35,64 @@ const profile = (displayName: string | null) => ({
   },
 });
 
-describe('ProfileScreen', () => {
-  const signOut = jest.fn().mockResolvedValue({});
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { gcTime: Infinity, retry: false },
+    },
+  });
+}
 
+function renderProfileScreen() {
+  const queryClient = createTestQueryClient();
+  const ui = () => (
+    <QueryClientProvider client={queryClient}>
+      <ProfileScreen />
+    </QueryClientProvider>
+  );
+  const result = render(ui());
+
+  return {
+    ...result,
+    queryClient,
+    rerenderProfile: () => result.rerender(ui()),
+  };
+}
+
+function authValue(accessToken = 'current-token') {
+  return {
+    invalidateSession: jest.fn().mockResolvedValue(undefined),
+    refreshSession: jest.fn().mockResolvedValue('refreshed-token'),
+    session: {
+      access_token: accessToken,
+      user: { id: 'user-1' },
+    },
+  } as unknown as ReturnType<typeof useAuth>;
+}
+
+describe('ProfileScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(useAuth).mockReturnValue({
-      session: { access_token: 'current-token' },
-      signOut,
-    } as unknown as ReturnType<typeof useAuth>);
+    jest.mocked(useAuth).mockReturnValue(authValue());
   });
 
   it('loads the server-backed display name using the current access token', async () => {
     jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
 
-    const { findByDisplayValue } = await render(<ProfileScreen />);
+    const { findByDisplayValue } = renderProfileScreen();
 
     expect(await findByDisplayValue('Taylor')).toBeTruthy();
     expect(getCurrentProfile).toHaveBeenCalledWith('current-token');
   });
 
-  it('saves then reloads the persisted server value before confirming success', async () => {
-    jest
-      .mocked(getCurrentProfile)
-      .mockResolvedValueOnce(profile('Taylor'))
-      .mockResolvedValueOnce(profile('Jordan Server'));
+  it('uses the persisted PATCH response to confirm a save without a second GET', async () => {
+    jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
     jest.mocked(updateCurrentProfile).mockResolvedValue({
-      ...profile('Jordan').profile,
+      ...profile('Jordan Server').profile,
     });
     const { findByDisplayValue, findByText, getByLabelText, getByText } =
-      await render(<ProfileScreen />);
+      renderProfileScreen();
 
     await findByDisplayValue('Taylor');
     await act(async () => {
@@ -71,6 +108,38 @@ describe('ProfileScreen', () => {
       'current-token',
       'Jordan',
     );
-    expect(getCurrentProfile).toHaveBeenCalledTimes(2);
+    expect(getCurrentProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves dirty input when the access token rotates or cached server data refreshes', async () => {
+    jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
+    const {
+      getByLabelText,
+      getByDisplayValue,
+      queryClient,
+      rerenderProfile,
+    } = renderProfileScreen();
+
+    await waitFor(() => {
+      expect(getByDisplayValue('Taylor')).toBeTruthy();
+    });
+    await act(async () => {
+      fireEvent.changeText(getByLabelText('Display name'), 'Unsaved Name');
+    });
+
+    jest.mocked(useAuth).mockReturnValue(authValue('refreshed-access-token'));
+    rerenderProfile();
+
+    await act(async () => {
+      queryClient.setQueryData(
+        ['current-profile', 'user-1'],
+        profile('Server Refreshed'),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getByDisplayValue('Unsaved Name')).toBeTruthy();
+    });
+    expect(getCurrentProfile).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
+++ b/apps/mobile/components/profile/__tests__/profile-screen.test.tsx
@@ -1,0 +1,76 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+
+import { ProfileScreen } from '@/components/profile/profile-screen';
+import { useAuth } from '@/lib/auth/auth-provider';
+import {
+  getCurrentProfile,
+  updateCurrentProfile,
+} from '@/lib/profile/profile-api';
+
+jest.mock('@/lib/auth/auth-provider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/profile/profile-api', () => ({
+  ...jest.requireActual('@/lib/profile/profile-api'),
+  getCurrentProfile: jest.fn(),
+  updateCurrentProfile: jest.fn(),
+}));
+
+const profile = (displayName: string | null) => ({
+  id: 'b1f4d587-4eef-4af8-899b-b2173ee42de0',
+  profile: {
+    created_at: '2026-08-31T10:00:00Z',
+    display_name: displayName,
+    updated_at: '2026-08-31T10:00:00Z',
+  },
+});
+
+describe('ProfileScreen', () => {
+  const signOut = jest.fn().mockResolvedValue({});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useAuth).mockReturnValue({
+      session: { access_token: 'current-token' },
+      signOut,
+    } as unknown as ReturnType<typeof useAuth>);
+  });
+
+  it('loads the server-backed display name using the current access token', async () => {
+    jest.mocked(getCurrentProfile).mockResolvedValue(profile('Taylor'));
+
+    const { findByDisplayValue } = await render(<ProfileScreen />);
+
+    expect(await findByDisplayValue('Taylor')).toBeTruthy();
+    expect(getCurrentProfile).toHaveBeenCalledWith('current-token');
+  });
+
+  it('saves then reloads the persisted server value before confirming success', async () => {
+    jest
+      .mocked(getCurrentProfile)
+      .mockResolvedValueOnce(profile('Taylor'))
+      .mockResolvedValueOnce(profile('Jordan Server'));
+    jest.mocked(updateCurrentProfile).mockResolvedValue({
+      ...profile('Jordan').profile,
+    });
+    const { findByDisplayValue, findByText, getByLabelText, getByText } =
+      await render(<ProfileScreen />);
+
+    await findByDisplayValue('Taylor');
+    await act(async () => {
+      fireEvent.changeText(getByLabelText('Display name'), 'Jordan');
+    });
+    await act(async () => {
+      fireEvent.press(getByText('Save profile'));
+    });
+
+    expect(await findByText('Profile saved.')).toBeTruthy();
+    expect(await findByDisplayValue('Jordan Server')).toBeTruthy();
+    expect(updateCurrentProfile).toHaveBeenCalledWith(
+      'current-token',
+      'Jordan',
+    );
+    expect(getCurrentProfile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/components/profile/profile-screen.tsx
+++ b/apps/mobile/components/profile/profile-screen.tsx
@@ -77,10 +77,7 @@ async function runWithAuthRetry<T>(
     try {
       return await operation(refreshedAccessToken);
     } catch (retryError) {
-      if (
-        retryError instanceof ProfileApiError &&
-        retryError.kind === 'auth'
-      ) {
+      if (retryError instanceof ProfileApiError && retryError.kind === 'auth') {
         await context.invalidateSession();
       }
       throw retryError;
@@ -127,26 +124,28 @@ export function ProfileScreen() {
     retry: false,
   });
 
-  const profileMutation = useMutation<ProfileResponse, ProfileApiError, string>({
-    mutationFn: async (displayName) => {
-      if (!accessToken) {
-        throw new ProfileApiError(
-          'auth',
-          'Your session has ended. Please sign in again.',
-        );
-      }
+  const profileMutation = useMutation<ProfileResponse, ProfileApiError, string>(
+    {
+      mutationFn: async (displayName) => {
+        if (!accessToken) {
+          throw new ProfileApiError(
+            'auth',
+            'Your session has ended. Please sign in again.',
+          );
+        }
 
-      return runWithAuthRetry(
-        (token) => updateCurrentProfile(token, displayName),
-        {
-          accessToken,
-          invalidateSession,
-          refreshSession,
-        },
-      );
+        return runWithAuthRetry(
+          (token) => updateCurrentProfile(token, displayName),
+          {
+            accessToken,
+            invalidateSession,
+            refreshSession,
+          },
+        );
+      },
+      retry: false,
     },
-    retry: false,
-  });
+  );
 
   useEffect(() => {
     if (profileQuery.data && !isDirty) {

--- a/apps/mobile/components/profile/profile-screen.tsx
+++ b/apps/mobile/components/profile/profile-screen.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useCallback, useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import {
   ActivityIndicator,
@@ -11,12 +12,14 @@ import {
 } from 'react-native';
 import { z } from 'zod';
 
+import { useAuth } from '@/lib/auth/auth-provider';
 import {
   getCurrentProfile,
+  type CurrentProfile,
   ProfileApiError,
+  type ProfileResponse,
   updateCurrentProfile,
 } from '@/lib/profile/profile-api';
-import { useAuth } from '@/lib/auth/auth-provider';
 
 const displayNameSchema = z.object({
   displayName: z
@@ -28,6 +31,16 @@ const displayNameSchema = z.object({
 
 type DisplayNameValues = z.infer<typeof displayNameSchema>;
 
+type AuthenticatedRequestContext = {
+  accessToken: string;
+  invalidateSession: () => Promise<void>;
+  refreshSession: () => Promise<string | null>;
+};
+
+function profileQueryKey(userId: string) {
+  return ['current-profile', userId] as const;
+}
+
 function feedbackFor(error: unknown): string {
   if (error instanceof ProfileApiError) {
     return error.message;
@@ -36,15 +49,53 @@ function feedbackFor(error: unknown): string {
   return 'Your profile could not be loaded. Please try again.';
 }
 
+async function runWithAuthRetry<T>(
+  operation: (accessToken: string) => Promise<T>,
+  context: AuthenticatedRequestContext,
+): Promise<T> {
+  try {
+    return await operation(context.accessToken);
+  } catch (error) {
+    if (!(error instanceof ProfileApiError) || error.kind !== 'auth') {
+      throw error;
+    }
+
+    let refreshedAccessToken: string | null;
+    try {
+      refreshedAccessToken = await context.refreshSession();
+    } catch {
+      throw new ProfileApiError(
+        'network',
+        'We could not refresh your session. Check your connection and try again.',
+      );
+    }
+
+    if (!refreshedAccessToken) {
+      throw error;
+    }
+
+    try {
+      return await operation(refreshedAccessToken);
+    } catch (retryError) {
+      if (
+        retryError instanceof ProfileApiError &&
+        retryError.kind === 'auth'
+      ) {
+        await context.invalidateSession();
+      }
+      throw retryError;
+    }
+  }
+}
+
 export function ProfileScreen() {
-  const { invalidateSession, session } = useAuth();
-  const [isLoading, setIsLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const { invalidateSession, refreshSession, session } = useAuth();
+  const queryClient = useQueryClient();
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const {
     control,
-    formState: { errors, isSubmitting },
+    formState: { errors, isDirty, isSubmitting },
     handleSubmit,
     reset,
   } = useForm<DisplayNameValues>({
@@ -52,102 +103,89 @@ export function ProfileScreen() {
     resolver: zodResolver(displayNameSchema),
   });
 
-  const handleAuthFailure = useCallback(
-    async (error: ProfileApiError): Promise<void> => {
-      if (error.kind === 'auth') {
-        await invalidateSession();
+  const accessToken = session?.access_token ?? null;
+  const userId = session?.user.id ?? null;
+  const queryKey = profileQueryKey(userId ?? 'signed-out');
+
+  const profileQuery = useQuery<CurrentProfile, ProfileApiError>({
+    enabled: Boolean(accessToken && userId),
+    queryKey,
+    queryFn: async () => {
+      if (!accessToken) {
+        throw new ProfileApiError(
+          'auth',
+          'Your session has ended. Please sign in again.',
+        );
       }
+
+      return runWithAuthRetry(getCurrentProfile, {
+        accessToken,
+        invalidateSession,
+        refreshSession,
+      });
     },
-    [invalidateSession],
-  );
+    retry: false,
+  });
 
-  const loadProfile = useCallback(async () => {
-    const accessToken = session?.access_token;
-    if (!accessToken) {
-      return;
-    }
-
-    setIsLoading(true);
-    setLoadError(null);
-    setSubmissionError(null);
-    setSuccessMessage(null);
-
-    try {
-      const currentProfile = await getCurrentProfile(accessToken);
-      reset({ displayName: currentProfile.profile.display_name ?? '' });
-    } catch (error) {
-      if (error instanceof ProfileApiError) {
-        await handleAuthFailure(error);
+  const profileMutation = useMutation<ProfileResponse, ProfileApiError, string>({
+    mutationFn: async (displayName) => {
+      if (!accessToken) {
+        throw new ProfileApiError(
+          'auth',
+          'Your session has ended. Please sign in again.',
+        );
       }
-      setLoadError(feedbackFor(error));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [handleAuthFailure, reset, session?.access_token]);
+
+      return runWithAuthRetry(
+        (token) => updateCurrentProfile(token, displayName),
+        {
+          accessToken,
+          invalidateSession,
+          refreshSession,
+        },
+      );
+    },
+    retry: false,
+  });
 
   useEffect(() => {
-    let isCurrent = true;
-    const accessToken = session?.access_token;
-
-    const loadInitialProfile = async () => {
-      if (!accessToken) {
-        return;
-      }
-
-      try {
-        const currentProfile = await getCurrentProfile(accessToken);
-        if (isCurrent) {
-          reset({ displayName: currentProfile.profile.display_name ?? '' });
-        }
-      } catch (error) {
-        if (!isCurrent) {
-          return;
-        }
-
-        if (error instanceof ProfileApiError) {
-          await handleAuthFailure(error);
-        }
-        if (isCurrent) {
-          setLoadError(feedbackFor(error));
-        }
-      } finally {
-        if (isCurrent) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void loadInitialProfile();
-
-    return () => {
-      isCurrent = false;
-    };
-  }, [handleAuthFailure, reset, session?.access_token]);
+    if (profileQuery.data && !isDirty) {
+      reset({
+        displayName: profileQuery.data.profile.display_name ?? '',
+      });
+    }
+  }, [isDirty, profileQuery.data, reset]);
 
   const saveProfile = async ({ displayName }: DisplayNameValues) => {
-    const accessToken = session?.access_token;
-    if (!accessToken) {
-      setSubmissionError('Your session has ended. Please sign in again.');
-      return;
-    }
-
     setSubmissionError(null);
     setSuccessMessage(null);
 
     try {
-      await updateCurrentProfile(accessToken, displayName);
-      const persistedProfile = await getCurrentProfile(accessToken);
-      reset({ displayName: persistedProfile.profile.display_name ?? '' });
+      const persistedProfile = await profileMutation.mutateAsync(displayName);
+      queryClient.setQueryData<CurrentProfile>(queryKey, (currentProfile) => {
+        if (!currentProfile) {
+          return currentProfile;
+        }
+        return { ...currentProfile, profile: persistedProfile };
+      });
+      reset({ displayName: persistedProfile.display_name ?? '' });
       setSuccessMessage('Profile saved.');
     } catch (error) {
-      if (error instanceof ProfileApiError) {
-        await handleAuthFailure(error);
-      }
       setSubmissionError(feedbackFor(error));
     }
   };
 
-  if (isLoading) {
+  if (!accessToken || !userId) {
+    return (
+      <View style={styles.centered}>
+        <Text accessibilityLiveRegion="polite" style={styles.error}>
+          Your session has ended. Please sign in again.
+        </Text>
+      </View>
+    );
+  }
+
+  if (profileQuery.isPending) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator accessibilityLabel="Loading profile" />
@@ -156,25 +194,34 @@ export function ProfileScreen() {
     );
   }
 
-  if (loadError) {
+  if (profileQuery.isError && !profileQuery.data) {
     return (
       <View style={styles.centered}>
         <Text accessibilityRole="header" style={styles.title}>
           Profile
         </Text>
         <Text accessibilityLiveRegion="polite" style={styles.error}>
-          {loadError}
+          {feedbackFor(profileQuery.error)}
         </Text>
         <Pressable
           accessibilityRole="button"
-          onPress={() => void loadProfile()}
+          disabled={profileQuery.isFetching}
+          onPress={() => {
+            setSubmissionError(null);
+            setSuccessMessage(null);
+            void profileQuery.refetch();
+          }}
           style={styles.button}
         >
-          <Text style={styles.buttonText}>Try again</Text>
+          <Text style={styles.buttonText}>
+            {profileQuery.isFetching ? 'Retrying…' : 'Try again'}
+          </Text>
         </Pressable>
       </View>
     );
   }
+
+  const isSaving = isSubmitting || profileMutation.isPending;
 
   return (
     <View style={styles.container}>
@@ -196,7 +243,11 @@ export function ProfileScreen() {
             autoComplete="name"
             maxLength={80}
             onBlur={onBlur}
-            onChangeText={onChange}
+            onChangeText={(nextValue) => {
+              setSubmissionError(null);
+              setSuccessMessage(null);
+              onChange(nextValue);
+            }}
             returnKeyType="done"
             style={styles.input}
             textContentType="name"
@@ -222,13 +273,13 @@ export function ProfileScreen() {
 
       <Pressable
         accessibilityRole="button"
-        accessibilityState={{ busy: isSubmitting, disabled: isSubmitting }}
-        disabled={isSubmitting}
+        accessibilityState={{ busy: isSaving, disabled: isSaving }}
+        disabled={isSaving}
         onPress={handleSubmit(saveProfile)}
         style={styles.button}
       >
         <Text style={styles.buttonText}>
-          {isSubmitting ? 'Saving…' : 'Save profile'}
+          {isSaving ? 'Saving…' : 'Save profile'}
         </Text>
       </Pressable>
     </View>

--- a/apps/mobile/components/profile/profile-screen.tsx
+++ b/apps/mobile/components/profile/profile-screen.tsx
@@ -1,0 +1,272 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback, useEffect, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { z } from 'zod';
+
+import {
+  getCurrentProfile,
+  ProfileApiError,
+  updateCurrentProfile,
+} from '@/lib/profile/profile-api';
+import { useAuth } from '@/lib/auth/auth-provider';
+
+const displayNameSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, 'Enter a display name.')
+    .max(80, 'Use 80 characters or fewer.'),
+});
+
+type DisplayNameValues = z.infer<typeof displayNameSchema>;
+
+function feedbackFor(error: unknown): string {
+  if (error instanceof ProfileApiError) {
+    return error.message;
+  }
+
+  return 'Your profile could not be loaded. Please try again.';
+}
+
+export function ProfileScreen() {
+  const { invalidateSession, session } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    reset,
+  } = useForm<DisplayNameValues>({
+    defaultValues: { displayName: '' },
+    resolver: zodResolver(displayNameSchema),
+  });
+
+  const handleAuthFailure = useCallback(
+    async (error: ProfileApiError): Promise<void> => {
+      if (error.kind === 'auth') {
+        await invalidateSession();
+      }
+    },
+    [invalidateSession],
+  );
+
+  const loadProfile = useCallback(async () => {
+    const accessToken = session?.access_token;
+    if (!accessToken) {
+      return;
+    }
+
+    setIsLoading(true);
+    setLoadError(null);
+    setSubmissionError(null);
+    setSuccessMessage(null);
+
+    try {
+      const currentProfile = await getCurrentProfile(accessToken);
+      reset({ displayName: currentProfile.profile.display_name ?? '' });
+    } catch (error) {
+      if (error instanceof ProfileApiError) {
+        await handleAuthFailure(error);
+      }
+      setLoadError(feedbackFor(error));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [handleAuthFailure, reset, session?.access_token]);
+
+  useEffect(() => {
+    let isCurrent = true;
+    const accessToken = session?.access_token;
+
+    const loadInitialProfile = async () => {
+      if (!accessToken) {
+        return;
+      }
+
+      try {
+        const currentProfile = await getCurrentProfile(accessToken);
+        if (isCurrent) {
+          reset({ displayName: currentProfile.profile.display_name ?? '' });
+        }
+      } catch (error) {
+        if (!isCurrent) {
+          return;
+        }
+
+        if (error instanceof ProfileApiError) {
+          await handleAuthFailure(error);
+        }
+        if (isCurrent) {
+          setLoadError(feedbackFor(error));
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadInitialProfile();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [handleAuthFailure, reset, session?.access_token]);
+
+  const saveProfile = async ({ displayName }: DisplayNameValues) => {
+    const accessToken = session?.access_token;
+    if (!accessToken) {
+      setSubmissionError('Your session has ended. Please sign in again.');
+      return;
+    }
+
+    setSubmissionError(null);
+    setSuccessMessage(null);
+
+    try {
+      await updateCurrentProfile(accessToken, displayName);
+      const persistedProfile = await getCurrentProfile(accessToken);
+      reset({ displayName: persistedProfile.profile.display_name ?? '' });
+      setSuccessMessage('Profile saved.');
+    } catch (error) {
+      if (error instanceof ProfileApiError) {
+        await handleAuthFailure(error);
+      }
+      setSubmissionError(feedbackFor(error));
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator accessibilityLabel="Loading profile" />
+        <Text style={styles.loadingText}>Loading profile…</Text>
+      </View>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <View style={styles.centered}>
+        <Text accessibilityRole="header" style={styles.title}>
+          Profile
+        </Text>
+        <Text accessibilityLiveRegion="polite" style={styles.error}>
+          {loadError}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => void loadProfile()}
+          style={styles.button}
+        >
+          <Text style={styles.buttonText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text accessibilityRole="header" style={styles.title}>
+        Profile
+      </Text>
+      <Text style={styles.subtitle}>
+        Choose the name shown with your KeylorFit account.
+      </Text>
+
+      <Text style={styles.inputLabel}>Display name</Text>
+      <Controller
+        control={control}
+        name="displayName"
+        render={({ field: { onBlur, onChange, value } }) => (
+          <TextInput
+            accessibilityLabel="Display name"
+            autoCapitalize="words"
+            autoComplete="name"
+            maxLength={80}
+            onBlur={onBlur}
+            onChangeText={onChange}
+            returnKeyType="done"
+            style={styles.input}
+            textContentType="name"
+            value={value}
+          />
+        )}
+      />
+      {errors.displayName ? (
+        <Text accessibilityLiveRegion="polite" style={styles.error}>
+          {errors.displayName.message}
+        </Text>
+      ) : null}
+      {submissionError ? (
+        <Text accessibilityLiveRegion="polite" style={styles.error}>
+          {submissionError}
+        </Text>
+      ) : null}
+      {successMessage ? (
+        <Text accessibilityLiveRegion="polite" style={styles.success}>
+          {successMessage}
+        </Text>
+      ) : null}
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ busy: isSubmitting, disabled: isSubmitting }}
+        disabled={isSubmitting}
+        onPress={handleSubmit(saveProfile)}
+        style={styles.button}
+      >
+        <Text style={styles.buttonText}>
+          {isSubmitting ? 'Saving…' : 'Save profile'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    backgroundColor: '#275dad',
+    borderRadius: 8,
+    justifyContent: 'center',
+    marginTop: 24,
+    minHeight: 48,
+    paddingHorizontal: 16,
+  },
+  buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
+  centered: { flex: 1, justifyContent: 'center', padding: 24 },
+  container: { backgroundColor: '#f7f9fc', flex: 1, padding: 24 },
+  error: { color: '#b42318', fontSize: 14, marginTop: 8 },
+  input: {
+    backgroundColor: '#ffffff',
+    borderColor: '#8b9ab2',
+    borderRadius: 8,
+    borderWidth: 1,
+    fontSize: 16,
+    marginTop: 8,
+    minHeight: 48,
+    paddingHorizontal: 12,
+  },
+  inputLabel: {
+    color: '#24344d',
+    fontSize: 15,
+    fontWeight: '600',
+    marginTop: 28,
+  },
+  loadingText: { color: '#4d5d74', fontSize: 16, marginTop: 12 },
+  subtitle: { color: '#4d5d74', fontSize: 16, lineHeight: 23, marginTop: 8 },
+  success: { color: '#067647', fontSize: 14, marginTop: 8 },
+  title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
+});

--- a/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
+++ b/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
-import { Pressable, Text } from 'react-native';
 import type { Session } from '@supabase/supabase-js';
+import { Pressable, Text } from 'react-native';
 
 import { AuthProvider, useAuth, type AuthPhase } from '../auth-provider';
 import type { MobileSupabaseClient } from '../supabase';
@@ -10,9 +10,9 @@ type AuthListener = (
   session: Session | null,
 ) => void;
 
-function session(): Session {
+function session(accessToken = 'access-token'): Session {
   return {
-    access_token: 'access-token',
+    access_token: accessToken,
     expires_at: 1_999_999_999,
     expires_in: 3600,
     refresh_token: 'refresh-token',
@@ -29,6 +29,8 @@ function session(): Session {
 
 function createClient({
   initialSession = null,
+  refreshSessionValue = session('refreshed-access-token'),
+  refreshSessionError = null,
   restoreError = null,
   signInError = null,
   signUpSession = null,
@@ -36,6 +38,8 @@ function createClient({
   signOutError = null,
 }: {
   initialSession?: Session | null;
+  refreshSessionValue?: Session | null;
+  refreshSessionError?: Error | null;
   restoreError?: Error | null;
   signInError?: Error | null;
   signUpError?: Error | null;
@@ -52,6 +56,10 @@ function createClient({
       onAuthStateChange: jest.fn((callback: AuthListener) => {
         listener = callback;
         return { data: { subscription: { unsubscribe: jest.fn() } } };
+      }),
+      refreshSession: jest.fn().mockResolvedValue({
+        data: { session: refreshSessionError ? null : refreshSessionValue },
+        error: refreshSessionError,
       }),
       signInWithPassword: jest.fn().mockResolvedValue({
         data: { session: signInError ? null : session() },
@@ -84,6 +92,8 @@ function AuthProbe() {
     feedback,
     invalidateSession,
     phase,
+    refreshSession,
+    session: currentSession,
     signIn,
     signOut,
     signUp,
@@ -94,6 +104,7 @@ function AuthProbe() {
       <Text testID="phase">{phase}</Text>
       <Text testID="confirmation">{confirmationEmail ?? ''}</Text>
       <Text testID="feedback">{feedback?.message ?? ''}</Text>
+      <Text testID="access-token">{currentSession?.access_token ?? ''}</Text>
       <Pressable
         onPress={() => void signIn('person@example.com', 'password123')}
       >
@@ -109,6 +120,9 @@ function AuthProbe() {
       </Pressable>
       <Pressable onPress={() => void invalidateSession()}>
         <Text>invalidate session</Text>
+      </Pressable>
+      <Pressable onPress={() => void refreshSession()}>
+        <Text>refresh session</Text>
       </Pressable>
     </>
   );
@@ -212,6 +226,53 @@ describe('AuthProvider', () => {
 
     await expectPhase(getByTestId, 'signedOut');
     expect(client.auth.signOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(getByTestId('feedback').props.children).toBe(
+      'Your session has ended. Please sign in again.',
+    );
+  });
+
+  it('refreshes an expired access token without ending a valid session', async () => {
+    const { client } = createClient({
+      initialSession: session('expired-access-token'),
+      refreshSessionValue: session('fresh-access-token'),
+    });
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedIn');
+    await act(async () => {
+      fireEvent.press(getByText('refresh session'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('access-token').props.children).toBe(
+        'fresh-access-token',
+      );
+    });
+    expect(getByTestId('phase').props.children).toBe('signedIn');
+    expect(client.auth.refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when an explicit refresh finds revoked credentials', async () => {
+    const { client } = createClient({
+      initialSession: session(),
+      refreshSessionError: new Error('Invalid refresh token: session revoked'),
+    });
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedIn');
+    await act(async () => {
+      fireEvent.press(getByText('refresh session'));
+    });
+
+    await expectPhase(getByTestId, 'signedOut');
     expect(getByTestId('feedback').props.children).toBe(
       'Your session has ended. Please sign in again.',
     );

--- a/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
+++ b/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
@@ -79,8 +79,15 @@ function createClient({
 }
 
 function AuthProbe() {
-  const { confirmationEmail, feedback, phase, signIn, signOut, signUp } =
-    useAuth();
+  const {
+    confirmationEmail,
+    feedback,
+    invalidateSession,
+    phase,
+    signIn,
+    signOut,
+    signUp,
+  } = useAuth();
 
   return (
     <>
@@ -99,6 +106,9 @@ function AuthProbe() {
       </Pressable>
       <Pressable onPress={() => void signOut()}>
         <Text>sign out</Text>
+      </Pressable>
+      <Pressable onPress={() => void invalidateSession()}>
+        <Text>invalidate session</Text>
       </Pressable>
     </>
   );
@@ -181,6 +191,30 @@ describe('AuthProvider', () => {
       fireEvent.press(getByText('sign out'));
     });
     await expectPhase(getByTestId, 'signedOut');
+  });
+
+  it('fails closed locally when terminal API auth invalidation cannot revoke remotely', async () => {
+    const remoteFailure = new Error('network failed');
+    const { client } = createClient({
+      initialSession: session(),
+      signOutError: remoteFailure,
+    });
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedIn');
+    await act(async () => {
+      fireEvent.press(getByText('invalidate session'));
+    });
+
+    await expectPhase(getByTestId, 'signedOut');
+    expect(client.auth.signOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(getByTestId('feedback').props.children).toBe(
+      'Your session has ended. Please sign in again.',
+    );
   });
 
   it('keeps the shell signed in after a successful token refresh', async () => {

--- a/apps/mobile/lib/auth/auth-provider.tsx
+++ b/apps/mobile/lib/auth/auth-provider.tsx
@@ -43,6 +43,7 @@ type RegistrationResult = AuthActionResult & {
 type AuthContextValue = AuthState & {
   clearConfirmation: () => void;
   invalidateSession: () => Promise<void>;
+  refreshSession: () => Promise<string | null>;
   signIn: (email: string, password: string) => Promise<AuthActionResult>;
   signOut: () => Promise<AuthActionResult>;
   signUp: (email: string, password: string) => Promise<RegistrationResult>;
@@ -144,6 +145,18 @@ export function AuthProvider({
     setAuthState(nextState);
   }, []);
 
+  const setTerminalSignedOutState = useCallback(() => {
+    updateAuthState({
+      confirmationEmail: null,
+      feedback: {
+        kind: 'terminal',
+        message: 'Your session has ended. Please sign in again.',
+      },
+      phase: 'signedOut',
+      session: null,
+    });
+  }, [updateAuthState]);
+
   const restoreSession = useCallback(async () => {
     if (!clientResult.client) {
       updateAuthState({
@@ -165,15 +178,7 @@ export function AuthProvider({
     }
 
     if (isTerminalSessionFailure(error)) {
-      updateAuthState({
-        confirmationEmail: null,
-        feedback: {
-          kind: 'terminal',
-          message: 'Your session has ended. Please sign in again.',
-        },
-        phase: 'signedOut',
-        session: null,
-      });
+      setTerminalSignedOutState();
       return;
     }
 
@@ -184,7 +189,12 @@ export function AuthProvider({
       phase: currentSession ? 'signedIn' : 'signedOut',
       session: currentSession,
     });
-  }, [clientResult.client, clientResult.error, updateAuthState]);
+  }, [
+    clientResult.client,
+    clientResult.error,
+    setTerminalSignedOutState,
+    updateAuthState,
+  ]);
 
   useEffect(() => {
     const client = clientResult.client;
@@ -208,15 +218,7 @@ export function AuthProvider({
         }
 
         if (event === 'TOKEN_REFRESHED' && !session) {
-          updateAuthState({
-            confirmationEmail: null,
-            feedback: {
-              kind: 'terminal',
-              message: 'Your session has ended. Please sign in again.',
-            },
-            phase: 'signedOut',
-            session: null,
-          });
+          setTerminalSignedOutState();
           return;
         }
 
@@ -250,7 +252,12 @@ export function AuthProvider({
       client.auth.stopAutoRefresh();
       data.subscription.unsubscribe();
     };
-  }, [clientResult.client, restoreSession, updateAuthState]);
+  }, [
+    clientResult.client,
+    restoreSession,
+    setTerminalSignedOutState,
+    updateAuthState,
+  ]);
 
   const signIn = useCallback(
     async (email: string, password: string): Promise<AuthActionResult> => {
@@ -315,6 +322,50 @@ export function AuthProvider({
     [clientResult.client, clientResult.error, updateAuthState],
   );
 
+  /**
+   * Refreshes the Supabase session for a protected API retry.
+   *
+   * A terminal refresh failure signs the app out and returns null. Transient
+   * provider/network failures leave the current session intact and reject so the
+   * caller can surface a retryable error without destroying valid credentials.
+   */
+  const refreshSession = useCallback(async (): Promise<string | null> => {
+    const client = clientResult.client;
+    if (!client) {
+      setTerminalSignedOutState();
+      return null;
+    }
+
+    let response: Awaited<ReturnType<typeof client.auth.refreshSession>>;
+    try {
+      response = await client.auth.refreshSession();
+    } catch (error) {
+      const refreshError =
+        error instanceof Error ? error : new Error('session refresh failed');
+      if (isTerminalSessionFailure(refreshError)) {
+        setTerminalSignedOutState();
+        return null;
+      }
+      throw new Error(readableAuthError(refreshError));
+    }
+
+    if (response.error) {
+      if (isTerminalSessionFailure(response.error)) {
+        setTerminalSignedOutState();
+        return null;
+      }
+      throw new Error(readableAuthError(response.error));
+    }
+
+    if (!response.data.session) {
+      setTerminalSignedOutState();
+      return null;
+    }
+
+    updateAuthState(stateForSession(response.data.session));
+    return response.data.session.access_token;
+  }, [clientResult.client, setTerminalSignedOutState, updateAuthState]);
+
   const signOut = useCallback(async (): Promise<AuthActionResult> => {
     const client = clientResult.client;
     if (!client) {
@@ -339,17 +390,9 @@ export function AuthProvider({
     try {
       await clientResult.client?.auth.signOut({ scope: 'local' });
     } finally {
-      updateAuthState({
-        confirmationEmail: null,
-        feedback: {
-          kind: 'terminal',
-          message: 'Your session has ended. Please sign in again.',
-        },
-        phase: 'signedOut',
-        session: null,
-      });
+      setTerminalSignedOutState();
     }
-  }, [clientResult.client, updateAuthState]);
+  }, [clientResult.client, setTerminalSignedOutState]);
 
   const clearConfirmation = useCallback(() => {
     updateAuthState({ ...stateForSession(null), confirmationEmail: null });
@@ -360,11 +403,20 @@ export function AuthProvider({
       ...authState,
       clearConfirmation,
       invalidateSession,
+      refreshSession,
       signIn,
       signOut,
       signUp,
     }),
-    [authState, clearConfirmation, invalidateSession, signIn, signOut, signUp],
+    [
+      authState,
+      clearConfirmation,
+      invalidateSession,
+      refreshSession,
+      signIn,
+      signOut,
+      signUp,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/mobile/lib/auth/auth-provider.tsx
+++ b/apps/mobile/lib/auth/auth-provider.tsx
@@ -42,6 +42,7 @@ type RegistrationResult = AuthActionResult & {
 
 type AuthContextValue = AuthState & {
   clearConfirmation: () => void;
+  invalidateSession: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<AuthActionResult>;
   signOut: () => Promise<AuthActionResult>;
   signUp: (email: string, password: string) => Promise<RegistrationResult>;
@@ -330,6 +331,26 @@ export function AuthProvider({
     return {};
   }, [clientResult.client, updateAuthState]);
 
+  /**
+   * Ends this device's session after a terminal protected-API authentication
+   * failure. Local state is cleared even when Supabase cannot revoke remotely.
+   */
+  const invalidateSession = useCallback(async (): Promise<void> => {
+    try {
+      await clientResult.client?.auth.signOut({ scope: 'local' });
+    } finally {
+      updateAuthState({
+        confirmationEmail: null,
+        feedback: {
+          kind: 'terminal',
+          message: 'Your session has ended. Please sign in again.',
+        },
+        phase: 'signedOut',
+        session: null,
+      });
+    }
+  }, [clientResult.client, updateAuthState]);
+
   const clearConfirmation = useCallback(() => {
     updateAuthState({ ...stateForSession(null), confirmationEmail: null });
   }, [updateAuthState]);
@@ -338,11 +359,12 @@ export function AuthProvider({
     () => ({
       ...authState,
       clearConfirmation,
+      invalidateSession,
       signIn,
       signOut,
       signUp,
     }),
-    [authState, clearConfirmation, signIn, signOut, signUp],
+    [authState, clearConfirmation, invalidateSession, signIn, signOut, signUp],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/mobile/lib/profile/__tests__/profile-api.test.ts
+++ b/apps/mobile/lib/profile/__tests__/profile-api.test.ts
@@ -1,0 +1,97 @@
+import { requestApi } from '@/lib/api/client';
+import {
+  getCurrentProfile,
+  ProfileApiError,
+  updateCurrentProfile,
+} from '@/lib/profile/profile-api';
+
+jest.mock('@/lib/api/client', () => ({
+  requestApi: jest.fn(),
+}));
+
+const currentProfile = {
+  id: 'b1f4d587-4eef-4af8-899b-b2173ee42de0',
+  profile: {
+    created_at: '2026-08-31T10:00:00Z',
+    display_name: 'Taylor',
+    updated_at: '2026-08-31T10:00:00Z',
+  },
+};
+
+describe('profile API client', () => {
+  beforeEach(() => {
+    jest.mocked(requestApi).mockReset();
+  });
+
+  it('fetches only the current caller profile with their bearer token', async () => {
+    jest.mocked(requestApi).mockResolvedValue({
+      json: async () => currentProfile,
+      ok: true,
+      status: 200,
+    } as Response);
+
+    await expect(getCurrentProfile('current-token')).resolves.toEqual(
+      currentProfile,
+    );
+    expect(requestApi).toHaveBeenCalledWith('/me', {
+      headers: { Authorization: 'Bearer current-token' },
+    });
+  });
+
+  it('updates only display_name and accepts the PATCH profile response', async () => {
+    const updatedProfile = {
+      ...currentProfile.profile,
+      display_name: 'Jordan',
+    };
+    jest.mocked(requestApi).mockResolvedValue({
+      json: async () => updatedProfile,
+      ok: true,
+      status: 200,
+    } as Response);
+
+    await expect(
+      updateCurrentProfile('current-token', 'Jordan'),
+    ).resolves.toEqual(updatedProfile);
+    expect(requestApi).toHaveBeenCalledWith('/me/profile', {
+      body: JSON.stringify({ display_name: 'Jordan' }),
+      headers: {
+        Authorization: 'Bearer current-token',
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    });
+  });
+
+  it.each([
+    [401, 'auth', 'Your session has ended. Please sign in again.'],
+    [403, 'forbidden', 'You are not authorized to access this profile.'],
+    [
+      503,
+      'server',
+      'The profile service is temporarily unavailable. Please try again.',
+    ],
+  ] as const)('classifies HTTP %i safely', async (status, kind, message) => {
+    jest.mocked(requestApi).mockResolvedValue({
+      json: async () => ({ detail: 'not shown to the user' }),
+      ok: false,
+      status,
+    } as Response);
+
+    await expect(getCurrentProfile('current-token')).rejects.toMatchObject({
+      kind,
+      message,
+    } satisfies Partial<ProfileApiError>);
+  });
+
+  it('reports connection failures without treating them as a successful save', async () => {
+    jest.mocked(requestApi).mockRejectedValue(new TypeError('network failed'));
+
+    await expect(
+      updateCurrentProfile('current-token', 'Jordan'),
+    ).rejects.toMatchObject({
+      kind: 'network',
+      message:
+        'We could not save your profile. Check your connection and try again.',
+    } satisfies Partial<ProfileApiError>);
+  });
+});

--- a/apps/mobile/lib/profile/profile-api.ts
+++ b/apps/mobile/lib/profile/profile-api.ts
@@ -1,0 +1,183 @@
+import { requestApi } from '@/lib/api/client';
+
+export type CurrentProfile = {
+  id: string;
+  profile: ProfileResponse;
+};
+
+export type ProfileResponse = {
+  created_at: string;
+  display_name: string | null;
+  updated_at: string;
+};
+
+export type ProfileApiErrorKind =
+  'auth' | 'forbidden' | 'validation' | 'server' | 'network' | 'unexpected';
+
+export class ProfileApiError extends Error {
+  constructor(
+    public readonly kind: ProfileApiErrorKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ProfileApiError';
+  }
+}
+
+function isCurrentProfile(payload: unknown): payload is CurrentProfile {
+  if (typeof payload !== 'object' || payload === null) {
+    return false;
+  }
+
+  const { id, profile } = payload as Record<string, unknown>;
+  if (
+    typeof id !== 'string' ||
+    typeof profile !== 'object' ||
+    profile === null
+  ) {
+    return false;
+  }
+
+  return isProfileResponse(profile);
+}
+
+function isProfileResponse(payload: unknown): payload is ProfileResponse {
+  if (typeof payload !== 'object' || payload === null) {
+    return false;
+  }
+
+  const { created_at, display_name, updated_at } = payload as Record<
+    string,
+    unknown
+  >;
+  return (
+    typeof created_at === 'string' &&
+    (typeof display_name === 'string' || display_name === null) &&
+    typeof updated_at === 'string'
+  );
+}
+
+async function messageFor(response: Response): Promise<string | null> {
+  try {
+    const payload: unknown = await response.json();
+    if (
+      typeof payload === 'object' &&
+      payload !== null &&
+      'detail' in payload &&
+      typeof payload.detail === 'string'
+    ) {
+      return payload.detail;
+    }
+  } catch {
+    // A body is optional for error responses.
+  }
+
+  return null;
+}
+
+async function profileResponse(response: Response): Promise<unknown> {
+  if (!response.ok) {
+    const detail = await messageFor(response);
+
+    if (response.status === 401) {
+      throw new ProfileApiError(
+        'auth',
+        'Your session has ended. Please sign in again.',
+      );
+    }
+
+    if (response.status === 403) {
+      throw new ProfileApiError(
+        'forbidden',
+        'You are not authorized to access this profile.',
+      );
+    }
+
+    if (response.status === 422) {
+      throw new ProfileApiError(
+        'validation',
+        detail ?? 'Enter a display name between 1 and 80 characters.',
+      );
+    }
+
+    if (response.status >= 500) {
+      throw new ProfileApiError(
+        'server',
+        'The profile service is temporarily unavailable. Please try again.',
+      );
+    }
+
+    throw new ProfileApiError(
+      'unexpected',
+      detail ?? 'Your profile could not be updated. Please try again.',
+    );
+  }
+
+  return response.json();
+}
+
+function authenticatedHeaders(accessToken: string): HeadersInit {
+  return { Authorization: `Bearer ${accessToken}` };
+}
+
+/** Reads the authenticated caller's application-owned profile. */
+export async function getCurrentProfile(
+  accessToken: string,
+): Promise<CurrentProfile> {
+  try {
+    const response = await requestApi('/me', {
+      headers: authenticatedHeaders(accessToken),
+    });
+    const payload = await profileResponse(response);
+    if (!isCurrentProfile(payload)) {
+      throw new ProfileApiError(
+        'unexpected',
+        'The profile service returned an unexpected response.',
+      );
+    }
+    return payload;
+  } catch (error) {
+    if (error instanceof ProfileApiError) {
+      throw error;
+    }
+
+    throw new ProfileApiError(
+      'network',
+      'We could not reach your profile. Check your connection and try again.',
+    );
+  }
+}
+
+/** Updates only the authenticated caller's profile; no owner identifier is sent. */
+export async function updateCurrentProfile(
+  accessToken: string,
+  displayName: string,
+): Promise<ProfileResponse> {
+  try {
+    const response = await requestApi('/me/profile', {
+      body: JSON.stringify({ display_name: displayName }),
+      headers: {
+        ...authenticatedHeaders(accessToken),
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    });
+    const payload = await profileResponse(response);
+    if (!isProfileResponse(payload)) {
+      throw new ProfileApiError(
+        'unexpected',
+        'The profile service returned an unexpected response.',
+      );
+    }
+    return payload;
+  } catch (error) {
+    if (error instanceof ProfileApiError) {
+      throw error;
+    }
+
+    throw new ProfileApiError(
+      'network',
+      'We could not save your profile. Check your connection and try again.',
+    );
+  }
+}

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@supabase/supabase-js": "^2.99.1",
+        "@tanstack/react-query": "^5.102.8",
         "expo": "~57.0.18",
         "expo-constants": "~57.0.15",
         "expo-linking": "~57.0.8",
@@ -3807,6 +3808,32 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.8.tgz",
+      "integrity": "sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.102.8.tgz",
+      "integrity": "sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.102.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/react-native": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@supabase/supabase-js": "^2.99.1",
+    "@tanstack/react-query": "^5.102.8",
     "expo": "~57.0.18",
     "expo-constants": "~57.0.15",
     "expo-linking": "~57.0.8",

--- a/database/migrations/versions/20260831_0001_add_profile_display_name.py
+++ b/database/migrations/versions/20260831_0001_add_profile_display_name.py
@@ -45,9 +45,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove the additive column while retaining restrictive table controls.
+    """Refuse a rollback that would discard persisted profile data.
 
-    Prior grants cannot be safely reconstructed, so a separate reviewed
-    migration is required if an environment must restore direct table access.
+    Once display names have been written, dropping the column would silently
+    destroy user data. Roll back this revision with a reviewed forward migration
+    that explicitly preserves or transforms those values instead.
     """
-    op.drop_column("application_user_profiles", "display_name")
+    raise NotImplementedError(
+        "20260831_0001 stores profile data and must be rolled forward, not dropped"
+    )

--- a/database/migrations/versions/20260831_0001_add_profile_display_name.py
+++ b/database/migrations/versions/20260831_0001_add_profile_display_name.py
@@ -1,0 +1,53 @@
+"""Add the editable application-owned profile display name.
+
+Revision ID: 20260831_0001
+Revises: 20260829_0001
+Create Date: 2026-08-31 00:00:00
+
+The nullable column is additive and leaves every existing and newly provisioned
+profile without a display name until the caller explicitly supplies one. The
+application identity tables are also restricted to the FastAPI database role:
+Supabase Data API roles receive no table privileges and no RLS policies.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260831_0001"
+down_revision: str | None = "20260829_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add display-name storage and restrict direct Data API table access."""
+    op.add_column(
+        "application_user_profiles",
+        sa.Column("display_name", sa.String(length=80), nullable=True),
+    )
+    for table_name in (
+        "application_users",
+        "application_user_identities",
+        "application_user_profiles",
+    ):
+        op.execute(f"ALTER TABLE public.{table_name} ENABLE ROW LEVEL SECURITY")
+        for role_name in ("anon", "authenticated", "service_role"):
+            op.execute(
+                f"DO $$ BEGIN "
+                f"IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role_name}') "
+                f"THEN EXECUTE 'REVOKE ALL PRIVILEGES ON TABLE public.{table_name} FROM {role_name}'; "
+                f"END IF; END $$;"
+            )
+
+
+def downgrade() -> None:
+    """Remove the additive column while retaining restrictive table controls.
+
+    Prior grants cannot be safely reconstructed, so a separate reviewed
+    migration is required if an environment must restore direct table access.
+    """
+    op.drop_column("application_user_profiles", "display_name")

--- a/database/src/keylornet_database/identity.py
+++ b/database/src/keylornet_database/identity.py
@@ -63,6 +63,30 @@ class ApplicationUserRepository:
 
         return user
 
+    def set_profile_display_name(
+        self, *, user: ApplicationUser, display_name: str
+    ) -> ApplicationUserProfile:
+        """Persist a display name for an active application's own profile.
+
+        The caller supplies the application user resolved from its authenticated
+        principal. This method flushes and reloads within the caller-owned
+        transaction, so the write is rolled back if the surrounding request
+        fails.
+        """
+        if user.lifecycle_state is not ApplicationUserLifecycle.ACTIVE:
+            raise TerminalIdentityError(
+                "the external identity has a terminal KeylorFit lifecycle state"
+            )
+
+        profile = user.profile
+        if profile is None:
+            raise RuntimeError("active application user is missing its profile foundation")
+
+        profile.display_name = display_name
+        self._session.flush()
+        self._session.refresh(profile)
+        return profile
+
     def _find_identity(
         self, auth_provider: AuthProvider, external_subject: UUID
     ) -> ApplicationUserIdentity | None:

--- a/database/src/keylornet_database/models.py
+++ b/database/src/keylornet_database/models.py
@@ -133,7 +133,7 @@ class ApplicationUserIdentity(Base):
 
 
 class ApplicationUserProfile(Base):
-    """One-to-one application-owned profile foundation without provider PII."""
+    """One-to-one application-owned profile data without provider PII."""
 
     __tablename__ = "application_user_profiles"
 
@@ -142,6 +142,7 @@ class ApplicationUserProfile(Base):
         ForeignKey("application_users.id", ondelete="RESTRICT"),
         primary_key=True,
     )
+    display_name: Mapped[str | None] = mapped_column(String(80))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/database/tests/test_migrations.py
+++ b/database/tests/test_migrations.py
@@ -99,6 +99,26 @@ def test_upgrade_clean_database_records_head(test_database_url: str) -> None:
     assert direct_grants == []
 
 
+def test_display_name_migration_refuses_destructive_downgrade(
+    test_database_url: str,
+) -> None:
+    """The profile migration must not silently drop persisted display names."""
+    config = Config("alembic.ini")
+
+    with pytest.raises(NotImplementedError, match="stores profile data"):
+        command.downgrade(config, "20260829_0001")
+
+    engine = create_engine(test_database_url)
+    try:
+        with engine.connect() as connection:
+            revision = connection.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar_one()
+        assert revision == "20260831_0001"
+    finally:
+        engine.dispose()
+
+
 def test_provisioning_is_idempotent_and_creates_profile(test_database_url: str) -> None:
     """Repeated first access maps one external subject to one active profile."""
     engine = create_engine(test_database_url)

--- a/database/tests/test_migrations.py
+++ b/database/tests/test_migrations.py
@@ -28,12 +28,16 @@ def test_upgrade_clean_database_records_head(test_database_url: str) -> None:
     """A clean PostgreSQL database upgrades to the baseline revision."""
     engine = create_engine(test_database_url)
     with engine.connect() as connection:
-        tables = connection.execute(
-            text(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = 'public' ORDER BY table_name"
+        tables = (
+            connection.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = 'public' ORDER BY table_name"
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     assert tables == [], "migration test requires a clean PostgreSQL test database"
 
@@ -41,9 +45,58 @@ def test_upgrade_clean_database_records_head(test_database_url: str) -> None:
     command.upgrade(config, "head")
 
     with engine.connect() as connection:
-        revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+        revision = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
 
-    assert revision == "20260829_0001"
+    assert revision == "20260831_0001"
+
+    with engine.connect() as connection:
+        display_name = connection.execute(
+            text(
+                "SELECT is_nullable, character_maximum_length "
+                "FROM information_schema.columns "
+                "WHERE table_schema = 'public' "
+                "AND table_name = 'application_user_profiles' "
+                "AND column_name = 'display_name'"
+            )
+        ).one()
+
+    assert display_name == ("YES", 80)
+
+    with engine.connect() as connection:
+        rls = connection.execute(
+            text(
+                "SELECT relation.relname, relation.relrowsecurity "
+                "FROM pg_class AS relation "
+                "JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace "
+                "WHERE namespace.nspname = 'public' "
+                "AND relation.relname IN ("
+                "'application_users', "
+                "'application_user_identities', "
+                "'application_user_profiles'"
+                ") ORDER BY relation.relname"
+            )
+        ).all()
+        direct_grants = connection.execute(
+            text(
+                "SELECT table_name, grantee, privilege_type "
+                "FROM information_schema.table_privileges "
+                "WHERE table_schema = 'public' "
+                "AND table_name IN ("
+                "'application_users', "
+                "'application_user_identities', "
+                "'application_user_profiles'"
+                ") AND grantee IN ('anon', 'authenticated', 'service_role')"
+            )
+        ).all()
+
+    assert rls == [
+        ("application_user_identities", True),
+        ("application_user_profiles", True),
+        ("application_users", True),
+    ]
+    assert direct_grants == []
 
 
 def test_provisioning_is_idempotent_and_creates_profile(test_database_url: str) -> None:
@@ -67,6 +120,36 @@ def test_provisioning_is_idempotent_and_creates_profile(test_database_url: str) 
             assert second.id == first_id
             assert second.profile is not None
             session.commit()
+    finally:
+        engine.dispose()
+
+
+def test_display_name_is_initially_null_and_persists_across_sessions(
+    test_database_url: str,
+) -> None:
+    """A profile starts empty and keeps a repository update after commit."""
+    engine = create_engine(test_database_url)
+    subject = uuid4()
+    try:
+        with Session(engine) as session:
+            repository = ApplicationUserRepository(session)
+            user = repository.get_or_provision_active_user(
+                auth_provider=AuthProvider.SUPABASE, external_subject=subject
+            )
+            assert user.profile is not None
+            assert user.profile.display_name is None
+
+            repository.set_profile_display_name(user=user, display_name="Jonathan")
+            session.commit()
+
+        with Session(engine) as session:
+            persisted_user = ApplicationUserRepository(
+                session
+            ).get_or_provision_active_user(
+                auth_provider=AuthProvider.SUPABASE, external_subject=subject
+            )
+            assert persisted_user.profile is not None
+            assert persisted_user.profile.display_name == "Jonathan"
     finally:
         engine.dispose()
 

--- a/services/api/app/identity/router.py
+++ b/services/api/app/identity/router.py
@@ -7,8 +7,15 @@ from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_authenticated_principal, get_database_session
 from app.auth.jwt_verifier import AuthenticatedPrincipal
-from app.identity.schemas import MeResponse
-from app.identity.service import get_or_provision_current_identity
+from app.identity.schemas import (
+    MeResponse,
+    ProfileResponse,
+    UpdateProfileRequest,
+)
+from app.identity.service import (
+    get_or_provision_current_identity,
+    update_current_profile,
+)
 
 router = APIRouter(tags=["identity"])
 
@@ -20,3 +27,13 @@ def get_me(
 ) -> MeResponse:
     """Return only the authenticated caller's application identity foundation."""
     return get_or_provision_current_identity(principal=principal, session=session)
+
+
+@router.patch("/me/profile", response_model=ProfileResponse)
+def patch_my_profile(
+    update: UpdateProfileRequest,
+    principal: Annotated[AuthenticatedPrincipal, Depends(get_authenticated_principal)],
+    session: Annotated[Session, Depends(get_database_session)],
+) -> ProfileResponse:
+    """Update the authenticated caller's application-owned profile."""
+    return update_current_profile(principal=principal, session=session, update=update)

--- a/services/api/app/identity/schemas.py
+++ b/services/api/app/identity/schemas.py
@@ -3,18 +3,38 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
-class ProfileFoundationResponse(BaseModel):
-    """The intentionally minimal application-owned profile foundation."""
+class ProfileResponse(BaseModel):
+    """The caller-owned profile representation exposed by the API."""
 
+    display_name: str | None
     created_at: datetime
     updated_at: datetime
+
+
+class UpdateProfileRequest(BaseModel):
+    """The caller-owned profile fields editable during M1."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str
+
+    @field_validator("display_name")
+    @classmethod
+    def normalize_display_name(cls, value: str) -> str:
+        """Trim the supplied name and enforce the public profile contract."""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("display_name must not be empty")
+        if len(normalized) > 80:
+            raise ValueError("display_name must be at most 80 characters")
+        return normalized
 
 
 class MeResponse(BaseModel):
     """The active caller's own KeylorFit identity and profile foundation."""
 
     id: UUID
-    profile: ProfileFoundationResponse
+    profile: ProfileResponse

--- a/services/api/app/identity/schemas.py
+++ b/services/api/app/identity/schemas.py
@@ -28,6 +28,8 @@ class UpdateProfileRequest(BaseModel):
         normalized = value.strip()
         if not normalized:
             raise ValueError("display_name must not be empty")
+        if "\x00" in normalized:
+            raise ValueError("display_name must not contain NUL characters")
         if len(normalized) > 80:
             raise ValueError("display_name must be at most 80 characters")
         return normalized

--- a/services/api/app/identity/service.py
+++ b/services/api/app/identity/service.py
@@ -2,19 +2,24 @@
 
 from fastapi import HTTPException, status
 from keylornet_database.identity import ApplicationUserRepository, TerminalIdentityError
-from keylornet_database.models import AuthProvider
+from keylornet_database.models import ApplicationUser, AuthProvider
 from sqlalchemy.orm import Session
 
 from app.auth.jwt_verifier import AuthenticatedPrincipal
-from app.identity.schemas import MeResponse, ProfileFoundationResponse
+from app.identity.schemas import (
+    MeResponse,
+    ProfileResponse,
+    UpdateProfileRequest,
+)
 
 
 def get_or_provision_current_identity(
     *, principal: AuthenticatedPrincipal, session: Session
 ) -> MeResponse:
     """Return the caller's active identity, provisioning it once when necessary."""
+    repository = ApplicationUserRepository(session)
     try:
-        user = ApplicationUserRepository(session).get_or_provision_active_user(
+        user = repository.get_or_provision_active_user(
             auth_provider=AuthProvider.SUPABASE,
             external_subject=principal.external_subject,
         )
@@ -24,12 +29,46 @@ def get_or_provision_current_identity(
             detail="not authorized",
         ) from exc
 
+    return _profile_response_for_user(user)
+
+
+def update_current_profile(
+    *,
+    principal: AuthenticatedPrincipal,
+    session: Session,
+    update: UpdateProfileRequest,
+) -> ProfileResponse:
+    """Persist the authenticated caller's validated profile update."""
+    repository = ApplicationUserRepository(session)
+    try:
+        user = repository.get_or_provision_active_user(
+            auth_provider=AuthProvider.SUPABASE,
+            external_subject=principal.external_subject,
+        )
+        profile = repository.set_profile_display_name(
+            user=user, display_name=update.display_name
+        )
+    except TerminalIdentityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="not authorized",
+        ) from exc
+    return ProfileResponse(
+        display_name=profile.display_name,
+        created_at=profile.created_at,
+        updated_at=profile.updated_at,
+    )
+
+
+def _profile_response_for_user(user: ApplicationUser) -> MeResponse:
+    """Map an active application user to the caller-relative response contract."""
     profile = user.profile
     if profile is None:
         raise RuntimeError("active application user is missing its profile foundation")
     return MeResponse(
         id=user.id,
-        profile=ProfileFoundationResponse(
+        profile=ProfileResponse(
+            display_name=profile.display_name,
             created_at=profile.created_at,
             updated_at=profile.updated_at,
         ),

--- a/services/api/tests/test_identity.py
+++ b/services/api/tests/test_identity.py
@@ -1,15 +1,24 @@
-"""Contract tests for the caller-relative identity endpoint."""
+"""Contract tests for caller-relative identity and profile endpoints."""
 
 from datetime import UTC, datetime
+from typing import cast
 from uuid import uuid4
 
+import pytest
+from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 from app.auth.dependencies import get_database_session
-from app.auth.jwt_verifier import AuthenticatedPrincipal, JwksProviderUnavailableError
+from app.auth.jwt_verifier import (
+    AuthenticatedPrincipal,
+    AuthenticationError,
+    JwksProviderUnavailableError,
+)
 from app.config import Settings
 from app.identity import router as identity_router
-from app.identity.schemas import MeResponse, ProfileFoundationResponse
+from app.identity import service as identity_service
+from app.identity.schemas import MeResponse, ProfileResponse, UpdateProfileRequest
 from app.main import create_app
 
 
@@ -25,6 +34,11 @@ class _Verifier:
 class _UnavailableVerifier:
     def verify(self, token: str) -> AuthenticatedPrincipal:
         raise JwksProviderUnavailableError("provider timed out")
+
+
+class _InvalidVerifier:
+    def verify(self, token: str) -> AuthenticatedPrincipal:
+        raise AuthenticationError("invalid token")
 
 
 def test_me_rejects_a_missing_bearer_token() -> None:
@@ -57,7 +71,7 @@ def test_me_reports_jwks_provider_outage_as_retryable() -> None:
 
 
 def test_me_uses_the_authenticated_principal_not_a_client_identifier(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     caller_subject = uuid4()
     application_id = uuid4()
@@ -66,8 +80,10 @@ def test_me_uses_the_authenticated_principal_not_a_client_identifier(
     app.dependency_overrides[get_database_session] = lambda: iter((object(),))
     expected = MeResponse(
         id=application_id,
-        profile=ProfileFoundationResponse(
-            created_at=datetime.now(UTC), updated_at=datetime.now(UTC)
+        profile=ProfileResponse(
+            display_name=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         ),
     )
 
@@ -88,9 +104,153 @@ def test_me_uses_the_authenticated_principal_not_a_client_identifier(
 
     assert response.status_code == 200
     assert response.json()["id"] == str(application_id)
+    assert response.json()["profile"]["display_name"] is None
 
 
-def test_me_is_present_in_the_openapi_contract() -> None:
+def test_patch_my_profile_uses_only_the_authenticated_principal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    caller_subject = uuid4()
+    app = create_app(Settings(supabase_project_url="https://example.supabase.co"))
+    app.state.jwt_verifier = _Verifier(AuthenticatedPrincipal(caller_subject))
+    app.dependency_overrides[get_database_session] = lambda: iter((object(),))
+    expected = ProfileResponse(
+        display_name="Jonathan",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    def update_profile(
+        *,
+        principal: AuthenticatedPrincipal,
+        session: object,
+        update: UpdateProfileRequest,
+    ) -> ProfileResponse:
+        assert principal.external_subject == caller_subject
+        assert update.display_name == "Jonathan"
+        return expected
+
+    monkeypatch.setattr(identity_router, "update_current_profile", update_profile)
+    client = TestClient(app)
+
+    response = client.patch(
+        "/me/profile?user_id=another-user",
+        headers={"Authorization": "Bearer valid-token"},
+        json={"display_name": "  Jonathan  "},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["display_name"] == "Jonathan"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"display_name": "   "},
+        {"display_name": "a" * 81},
+        {"display_name": "Jonathan", "user_id": str(uuid4())},
+    ],
+)
+def test_patch_my_profile_rejects_invalid_or_owner_selecting_input(
+    payload: dict[str, str],
+) -> None:
+    app = create_app(Settings(supabase_project_url="https://example.supabase.co"))
+    app.state.jwt_verifier = _Verifier(AuthenticatedPrincipal(uuid4()))
+    app.dependency_overrides[get_database_session] = lambda: iter((object(),))
+    client = TestClient(app)
+
+    response = client.patch(
+        "/me/profile",
+        headers={"Authorization": "Bearer valid-token"},
+        json=payload,
+    )
+
+    assert response.status_code == 422
+
+
+def test_patch_my_profile_reports_jwks_provider_outage_as_retryable() -> None:
+    app = create_app(Settings(supabase_project_url="https://example.supabase.co"))
+    app.state.jwt_verifier = _UnavailableVerifier()
+    client = TestClient(app)
+
+    response = client.patch(
+        "/me/profile",
+        headers={"Authorization": "Bearer valid-token"},
+        json={"display_name": "Jonathan"},
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "authentication is temporarily unavailable"}
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [{}, {"Authorization": "Basic malformed"}],
+)
+def test_patch_my_profile_rejects_missing_or_malformed_bearer_token(
+    headers: dict[str, str],
+) -> None:
+    client = TestClient(create_app())
+
+    response = client.patch(
+        "/me/profile", headers=headers, json={"display_name": "Name"}
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_patch_my_profile_rejects_an_invalid_bearer_token() -> None:
+    app = create_app(Settings(supabase_project_url="https://example.supabase.co"))
+    app.state.jwt_verifier = _InvalidVerifier()
+    client = TestClient(app)
+
+    response = client.patch(
+        "/me/profile",
+        headers={"Authorization": "Bearer invalid-token"},
+        json={"display_name": "Name"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_patch_my_profile_preserves_terminal_identity_protection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _TerminalRepository:
+        def __init__(self, session: Session) -> None:
+            self._session = session
+
+        def get_or_provision_active_user(self, **_: object) -> object:
+            raise identity_service.TerminalIdentityError("terminal")
+
+        def set_profile_display_name(self, **_: object) -> object:
+            raise AssertionError("terminal identities must not be updated")
+
+    monkeypatch.setattr(
+        identity_service, "ApplicationUserRepository", _TerminalRepository
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        identity_service.update_current_profile(
+            principal=AuthenticatedPrincipal(uuid4()),
+            session=cast(Session, object()),
+            update=UpdateProfileRequest(display_name="Jonathan"),
+        )
+
+    assert raised.value.status_code == status.HTTP_403_FORBIDDEN
+    assert raised.value.detail == "not authorized"
+
+
+def test_profile_endpoints_are_present_in_the_openapi_contract() -> None:
     schema = create_app().openapi()
 
     assert schema["paths"]["/me"]["get"]["responses"]["200"]
+    patch_operation = schema["paths"]["/me/profile"]["patch"]
+    assert patch_operation["responses"]["200"]
+    assert "parameters" not in patch_operation
+    request_schema = schema["components"]["schemas"]["UpdateProfileRequest"]
+    assert request_schema["required"] == ["display_name"]
+    assert request_schema["additionalProperties"] is False
+    assert set(request_schema["properties"]) == {"display_name"}

--- a/services/api/tests/test_identity.py
+++ b/services/api/tests/test_identity.py
@@ -148,6 +148,7 @@ def test_patch_my_profile_uses_only_the_authenticated_principal(
     [
         {"display_name": "   "},
         {"display_name": "a" * 81},
+        {"display_name": "A\u0000B"},
         {"display_name": "Jonathan", "user_id": str(uuid4())},
     ],
 )


### PR DESCRIPTION
## Summary

Implement IDN-004 (#40): server-backed display-name editing for authenticated KeylorFit users.

## Changes

- Add caller-relative `PATCH /me/profile` with server-side normalization and validation, including NUL rejection.
- Persist nullable `display_name` through Alembic/SQLAlchemy and protect identity tables from direct Supabase Data API access with RLS and revoked client-role privileges.
- Add protected mobile Profile UI backed by TanStack Query.
- On protected API 401, refresh the Supabase session and retry once before treating the session as terminal.
- Preserve dirty profile edits across token rotation/server refreshes and use the persisted PATCH response directly after save.
- Refuse destructive downgrade of persisted profile data.

## Validation

Current candidate HEAD: `34ed178c8ccde131b6b28eca8095ba195f06cfe6`.

- Backend CI / Backend CI — PASS.
- Mobile CI / mobile-quality — PASS, including formatting, lint, TypeScript and Jest.
- Database Migration CI / Database migration validation — PASS against real PostgreSQL, with Alembic head `20260831_0001`.
- All six review findings raised on the initial implementation are addressed and all review threads are resolved.
- Physical Android acceptance — PASS.

## Physical Android acceptance

Validated on a real connected Android device with an existing confirmed development account:

1. Sign-in succeeded.
2. Profile loaded through the server-backed flow.
3. `display_name` was set to `Physical QA 60` and saved successfully.
4. The saved value persisted after navigating away and reopening Profile.
5. The saved value persisted after signing out and signing back in.
6. No auth, ownership, validation, network, or persistence error was observed during the acceptance flow.

The physical-device merge gate is cleared.

## Risks and assumptions

- FastAPI uses the database owner or a server role with the required RLS bypass/ownership; this remains a deployment-time verification item for the production PostgreSQL role.

## Rollback

Revision `20260831_0001` intentionally refuses destructive downgrade because `display_name` becomes persisted user data. Any rollback requires a reviewed forward migration that preserves or transforms stored values.

Fixes #40