### PR TITLE
feat(mobile): establish visual design foundation

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -5,7 +5,6 @@
     "version": "0.1.0",
     "scheme": "keylorfit",
     "orientation": "portrait",
-    "userInterfaceStyle": "automatic",
     "android": {
       "package": "com.jonathansalgadonieto.keylorfit"
     },

--- a/apps/mobile/app/confirmation.tsx
+++ b/apps/mobile/app/confirmation.tsx
@@ -10,7 +10,7 @@ function ConfirmationScreen() {
 
   return (
     <AuthScreen title="Check your email">
-      <Text style={authScreenStyles.link}>
+      <Text style={authScreenStyles.helper}>
         {confirmationEmail
           ? `We sent a confirmation link to ${confirmationEmail}. Confirm your email, then sign in.`
           : 'Confirm your email, then sign in.'}

--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { RequireAuthenticated } from '@/components/auth/auth-guards';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { ErrorMessage } from '@/components/ui/form';
+import { Screen } from '@/components/ui/screen';
+import { colors, spacing, typography } from '@/components/ui/tokens';
 import { useAuth } from '@/lib/auth/auth-provider';
 
 function HomeScreen() {
@@ -15,24 +20,23 @@ function HomeScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <Screen centered>
+      <Text style={styles.eyebrow}>TRAINING SPACE</Text>
       <Text accessibilityRole="header" style={styles.title}>
         Your training home
       </Text>
       <Text style={styles.message}>You are signed in to KeylorFit.</Text>
-      {error ? (
-        <Text accessibilityLiveRegion="polite" style={styles.error}>
-          {error}
+      <Card>
+        <Text style={styles.cardTitle}>Ready when you are</Text>
+        <Text style={styles.cardMessage}>
+          Your next training tools will appear here.
         </Text>
-      ) : null}
-      <Pressable
-        accessibilityRole="button"
-        onPress={onSignOut}
-        style={styles.button}
-      >
-        <Text style={styles.buttonText}>Sign out</Text>
-      </Pressable>
-    </View>
+      </Card>
+      {error ? <ErrorMessage>{error}</ErrorMessage> : null}
+      <View style={styles.signOut}>
+        <Button label="Sign out" onPress={onSignOut} tone="secondary" />
+      </View>
+    </Screen>
   );
 }
 
@@ -45,21 +49,34 @@ export default function HomeRoute() {
 }
 
 const styles = StyleSheet.create({
-  button: {
-    backgroundColor: '#275dad',
-    borderRadius: 8,
-    marginTop: 28,
-    minHeight: 48,
-    padding: 14,
+  cardMessage: {
+    color: colors.secondary,
+    fontSize: typography.body.fontSize,
+    marginTop: spacing.sm,
   },
-  buttonText: {
-    color: '#ffffff',
-    fontSize: 16,
+  cardTitle: {
+    color: colors.primary,
+    fontSize: typography.label.fontSize,
     fontWeight: '700',
-    textAlign: 'center',
   },
-  container: { flex: 1, justifyContent: 'center', padding: 24 },
-  error: { color: '#b42318', marginTop: 12 },
-  message: { color: '#4d5d74', fontSize: 16, marginTop: 12 },
-  title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
+  eyebrow: {
+    color: colors.accent,
+    fontSize: typography.eyebrow.fontSize,
+    fontWeight: '700',
+    letterSpacing: 1.4,
+  },
+  message: {
+    color: colors.secondary,
+    fontSize: typography.body.fontSize,
+    marginBottom: spacing.xl,
+    marginTop: spacing.sm,
+  },
+  signOut: { marginTop: spacing.xl },
+  title: {
+    color: colors.primary,
+    fontSize: typography.display.fontSize,
+    fontWeight: '700',
+    lineHeight: typography.display.lineHeight,
+    marginTop: spacing.sm,
+  },
 });

--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -7,7 +7,12 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ErrorMessage } from '@/components/ui/form';
 import { Screen } from '@/components/ui/screen';
-import { colors, spacing, typography } from '@/components/ui/tokens';
+import {
+  colors,
+  spacing,
+  touchTarget,
+  typography,
+} from '@/components/ui/tokens';
 import { useAuth } from '@/lib/auth/auth-provider';
 
 function HomeScreen() {
@@ -84,6 +89,8 @@ const styles = StyleSheet.create({
     fontSize: typography.label.fontSize,
     fontWeight: '700',
     marginTop: spacing.lg,
+    minHeight: touchTarget,
+    paddingVertical: spacing.md,
   },
   signOut: { marginTop: spacing.xl },
   title: {

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,9 +1,10 @@
 import { Link } from 'expo-router';
 import { Text } from 'react-native';
 
-import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
 import { RequireSignedOut } from '@/components/auth/auth-guards';
+import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
 import { EmailPasswordForm } from '@/components/auth/email-password-form';
+import { ErrorMessage } from '@/components/ui/form';
 import { useAuth } from '@/lib/auth/auth-provider';
 
 function SignInScreen() {
@@ -14,9 +15,7 @@ function SignInScreen() {
       subtitle="Use your KeylorFit email and password."
       title="Sign in"
     >
-      {feedback ? (
-        <Text style={authScreenStyles.error}>{feedback.message}</Text>
-      ) : null}
+      {feedback ? <ErrorMessage>{feedback.message}</ErrorMessage> : null}
       <EmailPasswordForm
         actionLabel="Sign in"
         onSubmit={({ email, password }) => signIn(email, password)}

--- a/apps/mobile/components/auth/auth-screen.tsx
+++ b/apps/mobile/components/auth/auth-screen.tsx
@@ -3,7 +3,12 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { Card } from '@/components/ui/card';
 import { Screen } from '@/components/ui/screen';
-import { colors, spacing, typography } from '@/components/ui/tokens';
+import {
+  colors,
+  spacing,
+  touchTarget,
+  typography,
+} from '@/components/ui/tokens';
 
 type AuthScreenProps = PropsWithChildren<{
   subtitle?: string;
@@ -28,16 +33,21 @@ export function AuthScreen({ children, subtitle, title }: AuthScreenProps) {
 }
 
 export const authScreenStyles = StyleSheet.create({
-  error: {
-    color: colors.danger,
-    fontSize: typography.caption.fontSize,
-    marginTop: spacing.md,
+  helper: {
+    color: colors.secondary,
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    marginTop: spacing.lg,
   },
   link: {
     color: colors.accent,
     fontSize: typography.label.fontSize,
     fontWeight: '700',
+    lineHeight: typography.label.lineHeight,
     marginTop: spacing.lg,
+    minHeight: touchTarget,
+    minWidth: touchTarget,
+    paddingVertical: spacing.md,
   },
 });
 

--- a/apps/mobile/components/auth/auth-screen.tsx
+++ b/apps/mobile/components/auth/auth-screen.tsx
@@ -1,6 +1,10 @@
 import type { PropsWithChildren } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { Card } from '@/components/ui/card';
+import { Screen } from '@/components/ui/screen';
+import { colors, spacing, typography } from '@/components/ui/tokens';
+
 type AuthScreenProps = PropsWithChildren<{
   subtitle?: string;
   title: string;
@@ -8,64 +12,54 @@ type AuthScreenProps = PropsWithChildren<{
 
 export function AuthScreen({ children, subtitle, title }: AuthScreenProps) {
   return (
-    <View style={styles.container}>
+    <Screen centered>
       <View style={styles.content}>
-        <Text accessibilityRole="header" style={styles.brand}>
-          KeylorFit
-        </Text>
-        <Text accessibilityRole="header" style={styles.title}>
-          {title}
-        </Text>
-        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
-        {children}
+        <Text style={styles.brand}>KEYLORFIT</Text>
+        <Card>
+          <Text accessibilityRole="header" style={styles.title}>
+            {title}
+          </Text>
+          {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+          {children}
+        </Card>
       </View>
-    </View>
+    </Screen>
   );
 }
 
 export const authScreenStyles = StyleSheet.create({
-  button: {
-    alignItems: 'center',
-    backgroundColor: '#275dad',
-    borderRadius: 8,
-    justifyContent: 'center',
-    minHeight: 48,
-    paddingHorizontal: 16,
+  error: {
+    color: colors.danger,
+    fontSize: typography.caption.fontSize,
+    marginTop: spacing.md,
   },
-  buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
-  error: { color: '#b42318', fontSize: 14, marginTop: 12 },
-  input: {
-    borderColor: '#8b9ab2',
-    borderRadius: 8,
-    borderWidth: 1,
-    fontSize: 16,
-    marginTop: 8,
-    minHeight: 48,
-    paddingHorizontal: 12,
+  link: {
+    color: colors.accent,
+    fontSize: typography.label.fontSize,
+    fontWeight: '700',
+    marginTop: spacing.lg,
   },
-  inputLabel: {
-    color: '#24344d',
-    fontSize: 15,
-    fontWeight: '600',
-    marginTop: 16,
-  },
-  link: { color: '#1d4f91', fontSize: 16, fontWeight: '600', marginTop: 20 },
 });
 
 const styles = StyleSheet.create({
   brand: {
-    color: '#275dad',
-    fontSize: 20,
+    color: colors.accent,
+    fontSize: typography.eyebrow.fontSize,
     fontWeight: '700',
-    marginBottom: 28,
-  },
-  container: {
-    backgroundColor: '#f7f9fc',
-    flex: 1,
-    justifyContent: 'center',
-    padding: 24,
+    letterSpacing: 1.5,
+    marginBottom: spacing.md,
   },
   content: { width: '100%' },
-  subtitle: { color: '#4d5d74', fontSize: 16, lineHeight: 23, marginTop: 8 },
-  title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
+  subtitle: {
+    color: colors.secondary,
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    marginTop: spacing.sm,
+  },
+  title: {
+    color: colors.primary,
+    fontSize: typography.heading.fontSize,
+    fontWeight: '700',
+    lineHeight: typography.heading.lineHeight,
+  },
 });

--- a/apps/mobile/components/auth/email-password-form.tsx
+++ b/apps/mobile/components/auth/email-password-form.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { z } from 'zod';
 
-import { authScreenStyles } from '@/components/auth/auth-screen';
+import { Button } from '@/components/ui/button';
+import { ErrorMessage, FieldLabel, FormInput } from '@/components/ui/form';
+import { spacing } from '@/components/ui/tokens';
 
 const emailPasswordSchema = z.object({
   email: z.email('Enter a valid email address.'),
@@ -40,70 +42,60 @@ export function EmailPasswordForm({
 
   return (
     <View>
-      <Text style={authScreenStyles.inputLabel}>Email</Text>
+      <FieldLabel>Email</FieldLabel>
       <Controller
         control={control}
         name="email"
         render={({ field: { onBlur, onChange, value } }) => (
-          <TextInput
+          <FormInput
             accessibilityLabel="Email"
             autoCapitalize="none"
             autoComplete="email"
             keyboardType="email-address"
             onBlur={onBlur}
             onChangeText={onChange}
-            style={authScreenStyles.input}
             textContentType="emailAddress"
             value={value}
           />
         )}
       />
       {errors.email ? (
-        <Text style={styles.fieldError}>{errors.email.message}</Text>
+        <ErrorMessage>{errors.email.message}</ErrorMessage>
       ) : null}
 
-      <Text style={authScreenStyles.inputLabel}>Password</Text>
+      <FieldLabel>Password</FieldLabel>
       <Controller
         control={control}
         name="password"
         render={({ field: { onBlur, onChange, value } }) => (
-          <TextInput
+          <FormInput
             accessibilityLabel="Password"
             autoComplete="password"
             onBlur={onBlur}
             onChangeText={onChange}
             secureTextEntry
-            style={authScreenStyles.input}
             textContentType="password"
             value={value}
           />
         )}
       />
       {errors.password ? (
-        <Text style={styles.fieldError}>{errors.password.message}</Text>
+        <ErrorMessage>{errors.password.message}</ErrorMessage>
       ) : null}
 
-      {submissionError ? (
-        <Text accessibilityLiveRegion="polite" style={authScreenStyles.error}>
-          {submissionError}
-        </Text>
-      ) : null}
-      <Pressable
-        accessibilityRole="button"
-        accessibilityState={{ disabled: isSubmitting }}
-        disabled={isSubmitting}
-        onPress={handleSubmit(submit)}
-        style={[authScreenStyles.button, styles.button]}
-      >
-        <Text style={authScreenStyles.buttonText}>
-          {isSubmitting ? 'Please wait…' : actionLabel}
-        </Text>
-      </Pressable>
+      {submissionError ? <ErrorMessage>{submissionError}</ErrorMessage> : null}
+      <View style={styles.button}>
+        <Button
+          disabled={isSubmitting}
+          loading={isSubmitting}
+          onPress={handleSubmit(submit)}
+          label={isSubmitting ? 'Please wait…' : actionLabel}
+        />
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  button: { marginTop: 24 },
-  fieldError: { color: '#b42318', fontSize: 14, marginTop: 6 },
+  button: { marginTop: spacing.xl },
 });

--- a/apps/mobile/components/auth/session-restoring.tsx
+++ b/apps/mobile/components/auth/session-restoring.tsx
@@ -1,33 +1,24 @@
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
+
+import { LoadingState } from '@/components/ui/loading-state';
+import { Screen } from '@/components/ui/screen';
+import { colors, spacing, typography } from '@/components/ui/tokens';
 
 export function SessionRestoring() {
   return (
-    <View style={styles.container} testID="session-restoring">
-      <ActivityIndicator
-        accessibilityLabel="Restoring your session"
-        size="large"
-      />
-      <Text style={styles.title}>KeylorFit</Text>
-      <Text accessibilityLiveRegion="polite" style={styles.message}>
-        Restoring your session…
-      </Text>
-    </View>
+    <Screen centered>
+      <Text style={styles.brand}>KEYLORFIT</Text>
+      <LoadingState label="Restoring your session…" />
+    </Screen>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    backgroundColor: '#101b2d',
-    flex: 1,
-    justifyContent: 'center',
-    padding: 24,
-  },
-  message: { color: '#d9e4f7', fontSize: 16, marginTop: 12 },
-  title: {
-    color: '#ffffff',
-    fontSize: 32,
+  brand: {
+    color: colors.accent,
+    fontSize: typography.eyebrow.fontSize,
     fontWeight: '700',
-    marginTop: 20,
+    letterSpacing: 1.5,
+    marginBottom: spacing.md,
   },
 });

--- a/apps/mobile/components/profile/profile-screen.tsx
+++ b/apps/mobile/components/profile/profile-screen.tsx
@@ -5,13 +5,13 @@ import { Controller, useForm } from 'react-hook-form';
 import { StyleSheet, Text, View } from 'react-native';
 import { z } from 'zod';
 
-import { useAuth } from '@/lib/auth/auth-provider';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ErrorMessage, FieldLabel, FormInput } from '@/components/ui/form';
 import { LoadingState } from '@/components/ui/loading-state';
 import { Screen } from '@/components/ui/screen';
 import { colors, spacing, typography } from '@/components/ui/tokens';
+import { useAuth } from '@/lib/auth/auth-provider';
 import {
   getCurrentProfile,
   type CurrentProfile,
@@ -284,7 +284,7 @@ const styles = StyleSheet.create({
     marginTop: spacing.sm,
   },
   success: {
-    color: '#067647',
+    color: colors.success,
     fontSize: typography.caption.fontSize,
     marginTop: spacing.sm,
   },

--- a/apps/mobile/components/ui/__tests__/primitives.test.tsx
+++ b/apps/mobile/components/ui/__tests__/primitives.test.tsx
@@ -2,6 +2,26 @@ import { fireEvent, render } from '@testing-library/react-native';
 
 import { Button } from '@/components/ui/button';
 import { ErrorMessage, FieldLabel, FormInput } from '@/components/ui/form';
+import { colors, touchTarget } from '@/components/ui/tokens';
+
+function relativeLuminance(hex: string): number {
+  const channels = [1, 3, 5].map(
+    (start) => Number.parseInt(hex.slice(start, start + 2), 16) / 255,
+  );
+  const linear = channels.map((channel) =>
+    channel <= 0.04045
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrastRatio(first: string, second: string): number {
+  const lighter = Math.max(relativeLuminance(first), relativeLuminance(second));
+  const darker = Math.min(relativeLuminance(first), relativeLuminance(second));
+  return (lighter + 0.05) / (darker + 0.05);
+}
 
 describe('visual foundation primitives', () => {
   it('renders a touch-friendly primary button and invokes its action', async () => {
@@ -13,6 +33,7 @@ describe('visual foundation primitives', () => {
     fireEvent.press(getByRole('button', { name: 'Start training' }));
 
     expect(onPress).toHaveBeenCalledTimes(1);
+    expect(touchTarget).toBeGreaterThanOrEqual(48);
   });
 
   it('exposes labels, input semantics, and live validation feedback', async () => {
@@ -28,5 +49,14 @@ describe('visual foundation primitives', () => {
     expect(
       getByText('Enter a valid email address.').props.accessibilityLiveRegion,
     ).toBe('polite');
+  });
+
+  it('keeps accent text and controls at WCAG AA contrast', () => {
+    expect(
+      contrastRatio(colors.accent, colors.onAccent),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrastRatio(colors.accent, colors.background),
+    ).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/apps/mobile/components/ui/__tests__/primitives.test.tsx
+++ b/apps/mobile/components/ui/__tests__/primitives.test.tsx
@@ -4,22 +4,26 @@ import { Button } from '@/components/ui/button';
 import { ErrorMessage, FieldLabel, FormInput } from '@/components/ui/form';
 import { colors, touchTarget } from '@/components/ui/tokens';
 
-function relativeLuminance(hex: string): number {
-  const channels = [1, 3, 5].map(
-    (start) => Number.parseInt(hex.slice(start, start + 2), 16) / 255,
-  );
-  const linear = channels.map((channel) =>
-    channel <= 0.04045
-      ? channel / 12.92
-      : ((channel + 0.055) / 1.055) ** 2.4,
-  );
+function linearChannel(hex: string, start: number): number {
+  const encoded = Number.parseInt(hex.slice(start, start + 2), 16) / 255;
 
-  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+  return encoded <= 0.04045
+    ? encoded / 12.92
+    : ((encoded + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex: string): number {
+  const red = linearChannel(hex, 1);
+  const green = linearChannel(hex, 3);
+  const blue = linearChannel(hex, 5);
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 }
 
 function contrastRatio(first: string, second: string): number {
   const lighter = Math.max(relativeLuminance(first), relativeLuminance(second));
   const darker = Math.min(relativeLuminance(first), relativeLuminance(second));
+
   return (lighter + 0.05) / (darker + 0.05);
 }
 

--- a/apps/mobile/components/ui/__tests__/primitives.test.tsx
+++ b/apps/mobile/components/ui/__tests__/primitives.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { Button } from '@/components/ui/button';
+import { ErrorMessage, FieldLabel, FormInput } from '@/components/ui/form';
+
+describe('visual foundation primitives', () => {
+  it('renders a touch-friendly primary button and invokes its action', async () => {
+    const onPress = jest.fn();
+    const { getByRole } = await render(
+      <Button label="Start training" onPress={onPress} />,
+    );
+
+    fireEvent.press(getByRole('button', { name: 'Start training' }));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes labels, input semantics, and live validation feedback', async () => {
+    const { getByLabelText, getByText } = await render(
+      <>
+        <FieldLabel>Email</FieldLabel>
+        <FormInput accessibilityLabel="Email" />
+        <ErrorMessage>Enter a valid email address.</ErrorMessage>
+      </>,
+    );
+
+    expect(getByLabelText('Email')).toBeTruthy();
+    expect(
+      getByText('Enter a valid email address.').props.accessibilityLiveRegion,
+    ).toBe('polite');
+  });
+});

--- a/apps/mobile/components/ui/__tests__/primitives.test.tsx
+++ b/apps/mobile/components/ui/__tests__/primitives.test.tsx
@@ -52,11 +52,10 @@ describe('visual foundation primitives', () => {
   });
 
   it('keeps accent text and controls at WCAG AA contrast', () => {
-    expect(
-      contrastRatio(colors.accent, colors.onAccent),
-    ).toBeGreaterThanOrEqual(4.5);
-    expect(
-      contrastRatio(colors.accent, colors.background),
-    ).toBeGreaterThanOrEqual(4.5);
+    const controlContrast = contrastRatio(colors.accent, colors.onAccent);
+    const textContrast = contrastRatio(colors.accent, colors.background);
+
+    expect(controlContrast).toBeGreaterThanOrEqual(4.5);
+    expect(textContrast).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/apps/mobile/components/ui/button.tsx
+++ b/apps/mobile/components/ui/button.tsx
@@ -1,0 +1,79 @@
+import type { ComponentProps } from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+
+import {
+  colors,
+  radii,
+  spacing,
+  touchTarget,
+  typography,
+} from '@/components/ui/tokens';
+
+type ButtonTone = 'primary' | 'secondary' | 'destructive';
+type ButtonProps = Omit<
+  ComponentProps<typeof Pressable>,
+  'children' | 'style'
+> & {
+  loading?: boolean;
+  label: string;
+  tone?: ButtonTone;
+};
+
+export function Button({
+  disabled,
+  label,
+  loading = false,
+  tone = 'primary',
+  ...props
+}: ButtonProps) {
+  return (
+    <Pressable
+      {...props}
+      accessibilityRole="button"
+      accessibilityState={{ busy: loading, disabled: disabled ?? false }}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.button,
+        toneStyles[tone],
+        pressed && !disabled && pressedStyles[tone],
+        disabled && styles.disabled,
+      ]}
+    >
+      <Text style={[styles.label, labelStyles[tone]]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    borderRadius: radii.md,
+    justifyContent: 'center',
+    minHeight: touchTarget,
+    paddingHorizontal: spacing.lg,
+  },
+  disabled: { opacity: 0.5 },
+  label: { fontSize: typography.label.fontSize, fontWeight: '700' },
+});
+
+const toneStyles = StyleSheet.create({
+  destructive: { backgroundColor: colors.danger },
+  primary: { backgroundColor: colors.accent },
+  secondary: {
+    backgroundColor: colors.subtle,
+    borderColor: colors.border,
+    borderWidth: 1,
+  },
+});
+
+const pressedStyles = StyleSheet.create({
+  destructive: { backgroundColor: colors.dangerPressed },
+  primary: { backgroundColor: colors.accentPressed },
+  secondary: { backgroundColor: colors.border },
+});
+
+const labelStyles = StyleSheet.create({
+  destructive: { color: colors.onDanger },
+  primary: { color: colors.onAccent },
+  secondary: { color: colors.primary },
+});

--- a/apps/mobile/components/ui/card.tsx
+++ b/apps/mobile/components/ui/card.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { colors, elevation, radii, spacing } from '@/components/ui/tokens';
+
+export function Card({ children }: PropsWithChildren) {
+  return <View style={styles.card}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.card,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    padding: spacing.xl,
+    ...elevation,
+  },
+});

--- a/apps/mobile/components/ui/form.tsx
+++ b/apps/mobile/components/ui/form.tsx
@@ -1,0 +1,57 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { StyleSheet, Text, TextInput } from 'react-native';
+
+import {
+  colors,
+  radii,
+  spacing,
+  touchTarget,
+  typography,
+} from '@/components/ui/tokens';
+
+export function FormInput(props: ComponentProps<typeof TextInput>) {
+  return (
+    <TextInput
+      {...props}
+      placeholderTextColor={colors.secondary}
+      style={[styles.input, props.style]}
+    />
+  );
+}
+
+export function FieldLabel({ children }: { children: ReactNode }) {
+  return <Text style={styles.label}>{children}</Text>;
+}
+
+export function ErrorMessage({ children }: { children: ReactNode }) {
+  return (
+    <Text accessibilityLiveRegion="polite" style={styles.error}>
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  error: {
+    color: colors.danger,
+    fontSize: typography.caption.fontSize,
+    marginTop: spacing.sm,
+  },
+  input: {
+    backgroundColor: colors.card,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    color: colors.primary,
+    fontSize: typography.body.fontSize,
+    marginTop: spacing.sm,
+    minHeight: touchTarget,
+    paddingHorizontal: spacing.md,
+  },
+  label: {
+    color: colors.primary,
+    fontSize: typography.label.fontSize,
+    fontWeight: '700',
+    marginTop: spacing.lg,
+  },
+});

--- a/apps/mobile/components/ui/loading-state.tsx
+++ b/apps/mobile/components/ui/loading-state.tsx
@@ -1,0 +1,22 @@
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+import { colors, spacing, typography } from '@/components/ui/tokens';
+
+export function LoadingState({ label = 'Loading…' }: { label?: string }) {
+  return (
+    <View accessibilityRole="progressbar" style={styles.container}>
+      <ActivityIndicator color={colors.accent} />
+      <Text style={styles.label}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: spacing.md,
+    justifyContent: 'center',
+    padding: spacing.xl,
+  },
+  label: { color: colors.secondary, fontSize: typography.body.fontSize },
+});

--- a/apps/mobile/components/ui/screen.tsx
+++ b/apps/mobile/components/ui/screen.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+
+import { colors, spacing } from '@/components/ui/tokens';
+
+type ScreenProps = PropsWithChildren<{ centered?: boolean }>;
+
+export function Screen({ centered = false, children }: ScreenProps) {
+  return (
+    <ScrollView
+      contentContainerStyle={[styles.content, centered && styles.centered]}
+      keyboardShouldPersistTaps="handled"
+      style={styles.screen}
+    >
+      <View style={styles.inner}>{children}</View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: { flexGrow: 1, justifyContent: 'center' },
+  content: { padding: spacing.xl },
+  inner: { width: '100%' },
+  screen: { backgroundColor: colors.background, flex: 1 },
+});

--- a/apps/mobile/components/ui/screen.tsx
+++ b/apps/mobile/components/ui/screen.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { colors, spacing } from '@/components/ui/tokens';
 
@@ -7,13 +8,15 @@ type ScreenProps = PropsWithChildren<{ centered?: boolean }>;
 
 export function Screen({ centered = false, children }: ScreenProps) {
   return (
-    <ScrollView
-      contentContainerStyle={[styles.content, centered && styles.centered]}
-      keyboardShouldPersistTaps="handled"
-      style={styles.screen}
-    >
-      <View style={styles.inner}>{children}</View>
-    </ScrollView>
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView
+        contentContainerStyle={[styles.content, centered && styles.centered]}
+        keyboardShouldPersistTaps="handled"
+        style={styles.screen}
+      >
+        <View style={styles.inner}>{children}</View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
@@ -21,5 +24,6 @@ const styles = StyleSheet.create({
   centered: { flexGrow: 1, justifyContent: 'center' },
   content: { padding: spacing.xl },
   inner: { width: '100%' },
+  safeArea: { backgroundColor: colors.background, flex: 1 },
   screen: { backgroundColor: colors.background, flex: 1 },
 });

--- a/apps/mobile/components/ui/tokens.ts
+++ b/apps/mobile/components/ui/tokens.ts
@@ -14,6 +14,7 @@ export const colors = {
   primary: '#17211D',
   secondary: '#5D6761',
   subtle: '#E8ECE6',
+  success: '#067647',
 } as const;
 
 export const spacing = {

--- a/apps/mobile/components/ui/tokens.ts
+++ b/apps/mobile/components/ui/tokens.ts
@@ -1,0 +1,49 @@
+import { Platform } from 'react-native';
+
+/** Light-theme visual decisions for the KeylorFit mobile product. */
+export const colors = {
+  accent: '#D94F24',
+  accentPressed: '#B9401C',
+  background: '#F6F6F2',
+  border: '#D9DCD4',
+  card: '#FFFFFF',
+  danger: '#B42318',
+  dangerPressed: '#8E1C13',
+  onAccent: '#FFFFFF',
+  onDanger: '#FFFFFF',
+  primary: '#17211D',
+  secondary: '#5D6761',
+  subtle: '#E8ECE6',
+} as const;
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
+} as const;
+
+export const radii = { sm: 8, md: 12, lg: 18, pill: 999 } as const;
+
+export const typography = {
+  body: { fontSize: 16, lineHeight: 24 },
+  caption: { fontSize: 14, lineHeight: 20 },
+  display: { fontSize: 36, lineHeight: 42 },
+  eyebrow: { fontSize: 13, lineHeight: 18 },
+  heading: { fontSize: 28, lineHeight: 34 },
+  label: { fontSize: 15, lineHeight: 20 },
+} as const;
+
+export const touchTarget = 48;
+
+export const elevation = Platform.select({
+  android: { elevation: 2 },
+  default: {
+    shadowColor: '#17211D',
+    shadowOffset: { height: 4, width: 0 },
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+  },
+});

--- a/apps/mobile/components/ui/tokens.ts
+++ b/apps/mobile/components/ui/tokens.ts
@@ -2,8 +2,8 @@ import { Platform } from 'react-native';
 
 /** Light-theme visual decisions for the KeylorFit mobile product. */
 export const colors = {
-  accent: '#D94F24',
-  accentPressed: '#B9401C',
+  accent: '#C2411A',
+  accentPressed: '#A93616',
   background: '#F6F6F2',
   border: '#D9DCD4',
   card: '#FFFFFF',

--- a/apps/mobile/docs/visual-foundation.md
+++ b/apps/mobile/docs/visual-foundation.md
@@ -2,12 +2,14 @@
 
 The light-theme tokens live in `components/ui/tokens.ts`. Reusable primitives
 live beside them in `components/ui/`: `Screen`, `Card`, `Button`, form controls,
-and `LoadingState`.
+and `LoadingState`. `Screen` owns scrolling and safe-area handling so feature
+screens do not duplicate system-bar inset logic.
 
 M2 screens should compose these primitives first, use tokens rather than raw
 color or spacing values, and add a primitive only when it can serve more than
 one feature. Product-specific layout belongs with the feature, not the UI
 foundation.
 
-Dark mode is intentionally deferred. Do not add a theme framework or a dark
-palette until a product decision covers supported behavior and contrast.
+Dark mode is intentionally deferred. Keep the native appearance light until a
+product decision introduces a dark palette with verified contrast; do not add a
+theme framework in the meantime.

--- a/apps/mobile/docs/visual-foundation.md
+++ b/apps/mobile/docs/visual-foundation.md
@@ -1,0 +1,13 @@
+# KeylorFit visual foundation
+
+The light-theme tokens live in `components/ui/tokens.ts`. Reusable primitives
+live beside them in `components/ui/`: `Screen`, `Card`, `Button`, form controls,
+and `LoadingState`.
+
+M2 screens should compose these primitives first, use tokens rather than raw
+color or spacing values, and add a primitive only when it can serve more than
+one feature. Product-specific layout belongs with the feature, not the UI
+foundation.
+
+Dark mode is intentionally deferred. Do not add a theme framework or a dark
+palette until a product decision covers supported behavior and contrast.


### PR DESCRIPTION
## Summary

Establish the reusable light-theme visual foundation for KeylorFit mobile as UX-001.

## Changes

- Add design tokens and small React Native primitives for screens, cards, buttons, form controls, and loading states.
- Migrate the welcome/auth flow, session restoration, confirmation screen, and authenticated home without changing routing or authentication behavior.
- Add safe-area handling to the shared `Screen` primitive.
- Enforce a 48px minimum touch-target baseline for reusable controls/auth links.
- Use an accent palette that meets WCAG AA contrast for normal accent text and white text on primary controls.
- Keep native appearance explicitly light while dark mode remains intentionally deferred.
- Add focused primitive/accessibility tests and developer guidance for future M2 screens.

## Validation

Current candidate HEAD: `f3314fde324739fdf12bd8e65d1d09819a293c8a`.

- Backend CI / Backend CI — PASS.
- Mobile CI / mobile-quality — PASS, including repository-wide Prettier, lint, TypeScript and Jest.
- Mobile Jest — 6 suites, 24 tests PASS.
- Database Migration CI / Database migration validation — PASS.
- No backend, database, API, Supabase or auth-flow behavior was changed.

## Acceptance still required

- Product Owner visual review on a physical Android device.
- Basic Android smoke for safe areas, keyboard/form usability, touch targets and dynamic text/layout sanity.

## Merge ordering

PR #60 changes the authenticated home and adds Profile. Merge/accept #60 first, then update this branch from `main` and reconcile the visual foundation onto the resulting Home/Profile surface before merging UX-001. This avoids making #60 resolve the visual-foundation conflict while its identity acceptance is still pending.

## Risks and assumptions

- The visual system is intentionally light-theme-only; dark mode is deferred rather than partially supported.
- No large UI framework, icon set, animations, or illustration system is introduced.

## Rollback

Revert the UX-001 commits. The changes are mobile presentation primitives and do not change persisted data or backend contracts.

Fixes #51