### PR TITLE
feat(mobile): establish approved visual foundation

### DIFF
--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -16,10 +16,7 @@ function HomeScreen() {
   const { session, signOut } = useAuth();
   const [error, setError] = useState<string | null>(null);
   const email = session?.user.email ?? 'athlete';
-  const name =
-    session?.user.user_metadata.display_name ??
-    email.split('@')[0] ??
-    'Athlete';
+  const name = email.split('@')[0] || 'Athlete';
 
   const onSignOut = async () => {
     setError(null);

--- a/apps/mobile/app/home.tsx
+++ b/apps/mobile/app/home.tsx
@@ -1,13 +1,25 @@
 import { Link } from 'expo-router';
 import { useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { RequireAuthenticated } from '@/components/auth/auth-guards';
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { ErrorMessage } from '@/components/ui/form';
+import { Screen } from '@/components/ui/screen';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { colors, spacing, typography } from '@/components/ui/tokens';
 import { useAuth } from '@/lib/auth/auth-provider';
 
 function HomeScreen() {
-  const { signOut } = useAuth();
+  const { session, signOut } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const email = session?.user.email ?? 'athlete';
+  const name =
+    session?.user.user_metadata.display_name ??
+    email.split('@')[0] ??
+    'Athlete';
 
   const onSignOut = async () => {
     setError(null);
@@ -16,27 +28,51 @@ function HomeScreen() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text accessibilityRole="header" style={styles.title}>
-        Your training home
+    <Screen scroll>
+      <View style={styles.topRow}>
+        <View>
+          <Text style={styles.eyebrow}>KEYLORFIT</Text>
+          <Text accessibilityRole="header" style={styles.title}>
+            Ready to train?
+          </Text>
+        </View>
+        <Avatar name={name} />
+      </View>
+      <Text style={styles.subtitle}>
+        Your training home is ready when you are.
       </Text>
-      <Text style={styles.message}>You are signed in to KeylorFit.</Text>
-      <Link accessibilityRole="link" href="/profile" style={styles.profileLink}>
-        Profile
-      </Link>
-      {error ? (
-        <Text accessibilityLiveRegion="polite" style={styles.error}>
-          {error}
-        </Text>
-      ) : null}
-      <Pressable
-        accessibilityRole="button"
-        onPress={onSignOut}
-        style={styles.button}
-      >
-        <Text style={styles.buttonText}>Sign out</Text>
-      </Pressable>
-    </View>
+      <View style={styles.section}>
+        <SectionHeading title="Your account" />
+        <Card>
+          <Link
+            accessibilityRole="link"
+            href="/profile"
+            style={styles.profileLink}
+          >
+            <View>
+              <Text style={styles.cardTitle}>{name}</Text>
+              <Text style={styles.cardMeta}>{email}</Text>
+            </View>
+            <Text style={styles.arrow}>›</Text>
+          </Link>
+        </Card>
+      </View>
+      <View style={styles.section}>
+        <SectionHeading title="Training" />
+        <Card>
+          <Text style={styles.cardTitle}>Your next session starts here.</Text>
+          <Text style={styles.cardMeta}>
+            Workout tracking will appear here when it becomes available.
+          </Text>
+        </Card>
+      </View>
+      {error ? <ErrorMessage>{error}</ErrorMessage> : null}
+      <View style={styles.signOut}>
+        <Button variant="secondary" onPress={onSignOut}>
+          Sign out
+        </Button>
+      </View>
+    </Screen>
   );
 }
 
@@ -49,27 +85,30 @@ export default function HomeRoute() {
 }
 
 const styles = StyleSheet.create({
-  button: {
-    backgroundColor: '#275dad',
-    borderRadius: 8,
-    marginTop: 28,
-    minHeight: 48,
-    padding: 14,
+  arrow: { color: colors.training, fontSize: 28, fontWeight: '400' },
+  cardMeta: {
+    color: colors.textMuted,
+    marginTop: spacing.xs,
+    ...typography.caption,
   },
-  buttonText: {
-    color: '#ffffff',
-    fontSize: 16,
-    fontWeight: '700',
-    textAlign: 'center',
-  },
-  container: { flex: 1, justifyContent: 'center', padding: 24 },
-  error: { color: '#b42318', marginTop: 12 },
-  message: { color: '#4d5d74', fontSize: 16, marginTop: 12 },
+  cardTitle: { color: colors.text, ...typography.label },
+  eyebrow: { color: colors.progress, ...typography.caption },
   profileLink: {
-    color: '#1d4f91',
-    fontSize: 16,
-    fontWeight: '600',
-    marginTop: 24,
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
-  title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
+  section: { marginTop: spacing.xxl },
+  signOut: { marginTop: 'auto', paddingTop: spacing.xxxl },
+  subtitle: {
+    color: colors.textMuted,
+    marginTop: spacing.sm,
+    ...typography.body,
+  },
+  title: { color: colors.text, ...typography.title },
+  topRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
 });

--- a/apps/mobile/app/welcome.tsx
+++ b/apps/mobile/app/welcome.tsx
@@ -1,31 +1,64 @@
 import { Link } from 'expo-router';
-import { Text } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
 import { RequireSignedOut } from '@/components/auth/auth-guards';
+import { Screen } from '@/components/ui/screen';
+import { colors, radii, spacing, typography } from '@/components/ui/tokens';
 
 export default function WelcomeRoute() {
   return (
     <RequireSignedOut>
-      <AuthScreen
-        subtitle="Track the training that matters. Sign in to continue or create your account."
-        title="Welcome"
-      >
-        <Link
-          accessibilityRole="link"
-          href="/sign-in"
-          style={authScreenStyles.link}
-        >
-          <Text>Sign in</Text>
-        </Link>
-        <Link
-          accessibilityRole="link"
-          href="/sign-up"
-          style={authScreenStyles.link}
-        >
-          <Text>Create an account</Text>
-        </Link>
-      </AuthScreen>
+      <Screen>
+        <View style={styles.hero}>
+          <Text accessibilityRole="header" style={styles.brand}>
+            ⚡ KEYLOR<Text style={styles.brandAccent}>FIT</Text>
+          </Text>
+          <View style={styles.statement}>
+            <Text style={styles.display}>Train.</Text>
+            <Text style={[styles.display, styles.progress]}>Progress.</Text>
+            <Text style={[styles.display, styles.strength]}>Repeat.</Text>
+          </View>
+          <Text style={styles.copy}>
+            Your next training session starts with a simple, focused account.
+          </Text>
+        </View>
+        <View style={styles.actions}>
+          <Link accessibilityRole="link" asChild href="/sign-up">
+            <Pressable style={styles.primary}>
+              <Text style={styles.primaryText}>Create account</Text>
+            </Pressable>
+          </Link>
+          <Link accessibilityRole="link" href="/sign-in" style={styles.signIn}>
+            Already have an account? Sign in
+          </Link>
+        </View>
+      </Screen>
     </RequireSignedOut>
   );
 }
+
+const styles = StyleSheet.create({
+  actions: { gap: spacing.lg },
+  brand: { color: colors.text, ...typography.section },
+  brandAccent: { color: colors.progress },
+  copy: { color: colors.textMuted, maxWidth: 300, ...typography.body },
+  display: { color: colors.text, ...typography.display },
+  hero: {
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingBottom: spacing.xxxl,
+    paddingTop: spacing.lg,
+  },
+  primary: {
+    alignItems: 'center',
+    backgroundColor: colors.training,
+    borderRadius: radii.sm,
+    justifyContent: 'center',
+    minHeight: 52,
+  },
+  primaryText: { color: colors.onDark, ...typography.label },
+  progress: { color: colors.progress },
+  signIn: { color: colors.training, textAlign: 'center', ...typography.label },
+  statement: { gap: spacing.xs },
+  strength: { color: colors.strength },
+});

--- a/apps/mobile/app/welcome.tsx
+++ b/apps/mobile/app/welcome.tsx
@@ -3,7 +3,13 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { RequireSignedOut } from '@/components/auth/auth-guards';
 import { Screen } from '@/components/ui/screen';
-import { colors, radii, spacing, typography } from '@/components/ui/tokens';
+import {
+  colors,
+  radii,
+  spacing,
+  touchTarget,
+  typography,
+} from '@/components/ui/tokens';
 
 export default function WelcomeRoute() {
   return (
@@ -38,7 +44,7 @@ export default function WelcomeRoute() {
 }
 
 const styles = StyleSheet.create({
-  actions: { gap: spacing.lg },
+  actions: { gap: spacing.sm },
   brand: { color: colors.text, ...typography.section },
   brandAccent: { color: colors.progress },
   copy: { color: colors.textMuted, maxWidth: 300, ...typography.body },
@@ -58,7 +64,13 @@ const styles = StyleSheet.create({
   },
   primaryText: { color: colors.onDark, ...typography.label },
   progress: { color: colors.progress },
-  signIn: { color: colors.training, textAlign: 'center', ...typography.label },
+  signIn: {
+    color: colors.training,
+    minHeight: touchTarget,
+    paddingVertical: spacing.md,
+    textAlign: 'center',
+    ...typography.label,
+  },
   statement: { gap: spacing.xs },
   strength: { color: colors.strength },
 });

--- a/apps/mobile/components/auth/auth-screen.tsx
+++ b/apps/mobile/components/auth/auth-screen.tsx
@@ -2,7 +2,12 @@ import type { PropsWithChildren } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { Screen } from '@/components/ui/screen';
-import { colors, spacing, touchTarget, typography } from '@/components/ui/tokens';
+import {
+  colors,
+  spacing,
+  touchTarget,
+  typography,
+} from '@/components/ui/tokens';
 
 type AuthScreenProps = PropsWithChildren<{
   subtitle?: string;

--- a/apps/mobile/components/auth/auth-screen.tsx
+++ b/apps/mobile/components/auth/auth-screen.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { Screen } from '@/components/ui/screen';
-import { colors, spacing, typography } from '@/components/ui/tokens';
+import { colors, spacing, touchTarget, typography } from '@/components/ui/tokens';
 
 type AuthScreenProps = PropsWithChildren<{
   subtitle?: string;
@@ -30,7 +30,9 @@ export const authScreenStyles = StyleSheet.create({
   error: { color: colors.error, marginTop: spacing.md, ...typography.caption },
   link: {
     color: colors.training,
-    marginTop: spacing.lg,
+    marginTop: spacing.sm,
+    minHeight: touchTarget,
+    paddingVertical: spacing.md,
     textAlign: 'center',
     ...typography.label,
   },

--- a/apps/mobile/components/auth/auth-screen.tsx
+++ b/apps/mobile/components/auth/auth-screen.tsx
@@ -1,6 +1,9 @@
 import type { PropsWithChildren } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { Screen } from '@/components/ui/screen';
+import { colors, spacing, typography } from '@/components/ui/tokens';
+
 type AuthScreenProps = PropsWithChildren<{
   subtitle?: string;
   title: string;
@@ -8,10 +11,10 @@ type AuthScreenProps = PropsWithChildren<{
 
 export function AuthScreen({ children, subtitle, title }: AuthScreenProps) {
   return (
-    <View style={styles.container}>
+    <Screen scroll>
       <View style={styles.content}>
         <Text accessibilityRole="header" style={styles.brand}>
-          KeylorFit
+          ⚡ KEYLOR<Text style={styles.brandAccent}>FIT</Text>
         </Text>
         <Text accessibilityRole="header" style={styles.title}>
           {title}
@@ -19,53 +22,32 @@ export function AuthScreen({ children, subtitle, title }: AuthScreenProps) {
         {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
         {children}
       </View>
-    </View>
+    </Screen>
   );
 }
 
 export const authScreenStyles = StyleSheet.create({
-  button: {
-    alignItems: 'center',
-    backgroundColor: '#275dad',
-    borderRadius: 8,
-    justifyContent: 'center',
-    minHeight: 48,
-    paddingHorizontal: 16,
+  error: { color: colors.error, marginTop: spacing.md, ...typography.caption },
+  link: {
+    color: colors.training,
+    marginTop: spacing.lg,
+    textAlign: 'center',
+    ...typography.label,
   },
-  buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
-  error: { color: '#b42318', fontSize: 14, marginTop: 12 },
-  input: {
-    borderColor: '#8b9ab2',
-    borderRadius: 8,
-    borderWidth: 1,
-    fontSize: 16,
-    marginTop: 8,
-    minHeight: 48,
-    paddingHorizontal: 12,
-  },
-  inputLabel: {
-    color: '#24344d',
-    fontSize: 15,
-    fontWeight: '600',
-    marginTop: 16,
-  },
-  link: { color: '#1d4f91', fontSize: 16, fontWeight: '600', marginTop: 20 },
 });
 
 const styles = StyleSheet.create({
   brand: {
-    color: '#275dad',
-    fontSize: 20,
-    fontWeight: '700',
-    marginBottom: 28,
+    color: colors.text,
+    marginBottom: spacing.xxxl,
+    ...typography.section,
   },
-  container: {
-    backgroundColor: '#f7f9fc',
-    flex: 1,
-    justifyContent: 'center',
-    padding: 24,
+  brandAccent: { color: colors.progress },
+  content: { flex: 1, justifyContent: 'center', width: '100%' },
+  subtitle: {
+    color: colors.textMuted,
+    marginTop: spacing.sm,
+    ...typography.body,
   },
-  content: { width: '100%' },
-  subtitle: { color: '#4d5d74', fontSize: 16, lineHeight: 23, marginTop: 8 },
-  title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
+  title: { color: colors.text, ...typography.title },
 });

--- a/apps/mobile/components/auth/email-password-form.tsx
+++ b/apps/mobile/components/auth/email-password-form.tsx
@@ -1,10 +1,17 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { z } from 'zod';
 
-import { authScreenStyles } from '@/components/auth/auth-screen';
+import { Button } from '@/components/ui/button';
+import {
+  ErrorMessage,
+  FieldLabel,
+  FormInput,
+  PasswordInput,
+} from '@/components/ui/form';
+import { spacing } from '@/components/ui/tokens';
 
 const emailPasswordSchema = z.object({
   email: z.email('Enter a valid email address.'),
@@ -40,70 +47,56 @@ export function EmailPasswordForm({
 
   return (
     <View>
-      <Text style={authScreenStyles.inputLabel}>Email</Text>
+      <FieldLabel>Email</FieldLabel>
       <Controller
         control={control}
         name="email"
         render={({ field: { onBlur, onChange, value } }) => (
-          <TextInput
+          <FormInput
             accessibilityLabel="Email"
             autoCapitalize="none"
             autoComplete="email"
             keyboardType="email-address"
             onBlur={onBlur}
             onChangeText={onChange}
-            style={authScreenStyles.input}
             textContentType="emailAddress"
             value={value}
           />
         )}
       />
       {errors.email ? (
-        <Text style={styles.fieldError}>{errors.email.message}</Text>
+        <ErrorMessage>{errors.email.message}</ErrorMessage>
       ) : null}
 
-      <Text style={authScreenStyles.inputLabel}>Password</Text>
+      <FieldLabel>Password</FieldLabel>
       <Controller
         control={control}
         name="password"
         render={({ field: { onBlur, onChange, value } }) => (
-          <TextInput
+          <PasswordInput
             accessibilityLabel="Password"
             autoComplete="password"
             onBlur={onBlur}
             onChangeText={onChange}
-            secureTextEntry
-            style={authScreenStyles.input}
             textContentType="password"
             value={value}
           />
         )}
       />
       {errors.password ? (
-        <Text style={styles.fieldError}>{errors.password.message}</Text>
+        <ErrorMessage>{errors.password.message}</ErrorMessage>
       ) : null}
 
-      {submissionError ? (
-        <Text accessibilityLiveRegion="polite" style={authScreenStyles.error}>
-          {submissionError}
-        </Text>
-      ) : null}
-      <Pressable
-        accessibilityRole="button"
-        accessibilityState={{ disabled: isSubmitting }}
-        disabled={isSubmitting}
-        onPress={handleSubmit(submit)}
-        style={[authScreenStyles.button, styles.button]}
-      >
-        <Text style={authScreenStyles.buttonText}>
-          {isSubmitting ? 'Please wait…' : actionLabel}
-        </Text>
-      </Pressable>
+      {submissionError ? <ErrorMessage>{submissionError}</ErrorMessage> : null}
+      <View style={styles.button}>
+        <Button loading={isSubmitting} onPress={handleSubmit(submit)}>
+          {actionLabel}
+        </Button>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  button: { marginTop: 24 },
-  fieldError: { color: '#b42318', fontSize: 14, marginTop: 6 },
+  button: { marginTop: spacing.xl },
 });

--- a/apps/mobile/components/auth/session-restoring.tsx
+++ b/apps/mobile/components/auth/session-restoring.tsx
@@ -1,33 +1,20 @@
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { LoadingState } from '@/components/ui/feedback';
+import { colors, spacing, typography } from '@/components/ui/tokens';
 
 export function SessionRestoring() {
   return (
     <View style={styles.container} testID="session-restoring">
-      <ActivityIndicator
-        accessibilityLabel="Restoring your session"
-        size="large"
-      />
-      <Text style={styles.title}>KeylorFit</Text>
-      <Text accessibilityLiveRegion="polite" style={styles.message}>
-        Restoring your session…
+      <Text style={styles.brand}>
+        ⚡ KEYLOR<Text style={styles.brandAccent}>FIT</Text>
       </Text>
+      <LoadingState label="Restoring your session…" />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    backgroundColor: '#101b2d',
-    flex: 1,
-    justifyContent: 'center',
-    padding: 24,
-  },
-  message: { color: '#d9e4f7', fontSize: 16, marginTop: 12 },
-  title: {
-    color: '#ffffff',
-    fontSize: 32,
-    fontWeight: '700',
-    marginTop: 20,
-  },
+  brand: { color: colors.text, ...typography.section },
+  brandAccent: { color: colors.progress },
+  container: { backgroundColor: colors.canvas, flex: 1, padding: spacing.xl },
 });

--- a/apps/mobile/components/profile/profile-screen.tsx
+++ b/apps/mobile/components/profile/profile-screen.tsx
@@ -2,17 +2,17 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import {
-  ActivityIndicator,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { z } from 'zod';
 
 import { useAuth } from '@/lib/auth/auth-provider';
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { LoadingState } from '@/components/ui/feedback';
+import { ErrorMessage, FieldLabel, FormInput } from '@/components/ui/form';
+import { Screen } from '@/components/ui/screen';
+import { colors, spacing, typography } from '@/components/ui/tokens';
 import {
   getCurrentProfile,
   type CurrentProfile,
@@ -176,147 +176,128 @@ export function ProfileScreen() {
 
   if (!accessToken || !userId) {
     return (
-      <View style={styles.centered}>
-        <Text accessibilityLiveRegion="polite" style={styles.error}>
-          Your session has ended. Please sign in again.
-        </Text>
-      </View>
+      <Screen>
+        <View style={styles.centered}>
+          <ErrorMessage>
+            Your session has ended. Please sign in again.
+          </ErrorMessage>
+        </View>
+      </Screen>
     );
   }
 
   if (profileQuery.isPending) {
     return (
-      <View style={styles.centered}>
-        <ActivityIndicator accessibilityLabel="Loading profile" />
-        <Text style={styles.loadingText}>Loading profile…</Text>
-      </View>
+      <Screen>
+        <LoadingState label="Loading profile…" />
+      </Screen>
     );
   }
 
   if (profileQuery.isError && !profileQuery.data) {
     return (
-      <View style={styles.centered}>
-        <Text accessibilityRole="header" style={styles.title}>
-          Profile
-        </Text>
-        <Text accessibilityLiveRegion="polite" style={styles.error}>
-          {feedbackFor(profileQuery.error)}
-        </Text>
-        <Pressable
-          accessibilityRole="button"
-          disabled={profileQuery.isFetching}
-          onPress={() => {
-            setSubmissionError(null);
-            setSuccessMessage(null);
-            void profileQuery.refetch();
-          }}
-          style={styles.button}
-        >
-          <Text style={styles.buttonText}>
-            {profileQuery.isFetching ? 'Retrying…' : 'Try again'}
+      <Screen>
+        <View style={styles.centered}>
+          <Text accessibilityRole="header" style={styles.title}>
+            Profile
           </Text>
-        </Pressable>
-      </View>
+          <ErrorMessage>{feedbackFor(profileQuery.error)}</ErrorMessage>
+          <View style={styles.button}>
+            <Button
+              loading={profileQuery.isFetching}
+              onPress={() => {
+                setSubmissionError(null);
+                setSuccessMessage(null);
+                void profileQuery.refetch();
+              }}
+            >
+              Try again
+            </Button>
+          </View>
+        </View>
+      </Screen>
     );
   }
 
   const isSaving = isSubmitting || profileMutation.isPending;
 
   return (
-    <View style={styles.container}>
-      <Text accessibilityRole="header" style={styles.title}>
-        Profile
-      </Text>
-      <Text style={styles.subtitle}>
-        Choose the name shown with your KeylorFit account.
-      </Text>
+    <Screen scroll>
+      <View style={styles.header}>
+        <Avatar name={profileQuery.data?.profile.display_name} size={64} />
+        <View>
+          <Text accessibilityRole="header" style={styles.title}>
+            Profile
+          </Text>
+          <Text style={styles.subtitle}>
+            Choose the name shown with your KeylorFit account.
+          </Text>
+        </View>
+      </View>
 
-      <Text style={styles.inputLabel}>Display name</Text>
-      <Controller
-        control={control}
-        name="displayName"
-        render={({ field: { onBlur, onChange, value } }) => (
-          <TextInput
-            accessibilityLabel="Display name"
-            autoCapitalize="words"
-            autoComplete="name"
-            maxLength={80}
-            onBlur={onBlur}
-            onChangeText={(nextValue) => {
-              setSubmissionError(null);
-              setSuccessMessage(null);
-              onChange(nextValue);
-            }}
-            returnKeyType="done"
-            style={styles.input}
-            textContentType="name"
-            value={value}
-          />
-        )}
-      />
-      {errors.displayName ? (
-        <Text accessibilityLiveRegion="polite" style={styles.error}>
-          {errors.displayName.message}
-        </Text>
-      ) : null}
-      {submissionError ? (
-        <Text accessibilityLiveRegion="polite" style={styles.error}>
-          {submissionError}
-        </Text>
-      ) : null}
-      {successMessage ? (
-        <Text accessibilityLiveRegion="polite" style={styles.success}>
-          {successMessage}
-        </Text>
-      ) : null}
+      <Card>
+        <FieldLabel>Display name</FieldLabel>
+        <Controller
+          control={control}
+          name="displayName"
+          render={({ field: { onBlur, onChange, value } }) => (
+            <FormInput
+              accessibilityLabel="Display name"
+              autoCapitalize="words"
+              autoComplete="name"
+              maxLength={80}
+              onBlur={onBlur}
+              onChangeText={(nextValue) => {
+                setSubmissionError(null);
+                setSuccessMessage(null);
+                onChange(nextValue);
+              }}
+              returnKeyType="done"
+              textContentType="name"
+              value={value}
+            />
+          )}
+        />
+        {errors.displayName ? (
+          <ErrorMessage>{errors.displayName.message}</ErrorMessage>
+        ) : null}
+        {submissionError ? (
+          <ErrorMessage>{submissionError}</ErrorMessage>
+        ) : null}
+        {successMessage ? (
+          <Text accessibilityLiveRegion="polite" style={styles.success}>
+            {successMessage}
+          </Text>
+        ) : null}
 
-      <Pressable
-        accessibilityRole="button"
-        accessibilityState={{ busy: isSaving, disabled: isSaving }}
-        disabled={isSaving}
-        onPress={handleSubmit(saveProfile)}
-        style={styles.button}
-      >
-        <Text style={styles.buttonText}>
-          {isSaving ? 'Saving…' : 'Save profile'}
-        </Text>
-      </Pressable>
-    </View>
+        <View style={styles.button}>
+          <Button loading={isSaving} onPress={handleSubmit(saveProfile)}>
+            Save profile
+          </Button>
+        </View>
+      </Card>
+    </Screen>
   );
 }
 
 const styles = StyleSheet.create({
-  button: {
+  button: { marginTop: spacing.xl },
+  centered: { flex: 1, justifyContent: 'center' },
+  header: {
     alignItems: 'center',
-    backgroundColor: '#275dad',
-    borderRadius: 8,
-    justifyContent: 'center',
-    marginTop: 24,
-    minHeight: 48,
-    paddingHorizontal: 16,
+    flexDirection: 'row',
+    gap: spacing.lg,
+    marginBottom: spacing.xl,
   },
-  buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
-  centered: { flex: 1, justifyContent: 'center', padding: 24 },
-  container: { backgroundColor: '#f7f9fc', flex: 1, padding: 24 },
-  error: { color: '#b42318', fontSize: 14, marginTop: 8 },
-  input: {
-    backgroundColor: '#ffffff',
-    borderColor: '#8b9ab2',
-    borderRadius: 8,
-    borderWidth: 1,
-    fontSize: 16,
-    marginTop: 8,
-    minHeight: 48,
-    paddingHorizontal: 12,
+  subtitle: {
+    color: colors.textMuted,
+    marginTop: spacing.xs,
+    ...typography.caption,
   },
-  inputLabel: {
-    color: '#24344d',
-    fontSize: 15,
-    fontWeight: '600',
-    marginTop: 28,
+  success: {
+    color: colors.progress,
+    marginTop: spacing.sm,
+    ...typography.caption,
   },
-  loadingText: { color: '#4d5d74', fontSize: 16, marginTop: 12 },
-  subtitle: { color: '#4d5d74', fontSize: 16, lineHeight: 23, marginTop: 8 },
-  success: { color: '#067647', fontSize: 14, marginTop: 8 },
-  title: { color: '#101b2d', fontSize: 30, fontWeight: '700' },
+  title: { color: colors.text, ...typography.title },
 });

--- a/apps/mobile/components/ui/__tests__/foundation.test.tsx
+++ b/apps/mobile/components/ui/__tests__/foundation.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { ErrorMessage, PasswordInput } from '@/components/ui/form';
+import { LoadingState, Skeleton } from '@/components/ui/feedback';
+
+describe('visual foundation primitives', () => {
+  it('exposes disabled and loading button semantics', async () => {
+    const onPress = jest.fn();
+    const { getByRole } = await render(
+      <Button loading onPress={onPress}>
+        Continue
+      </Button>,
+    );
+    fireEvent.press(getByRole('button'));
+    expect(onPress).not.toHaveBeenCalled();
+    expect(getByRole('button').props.accessibilityState).toMatchObject({
+      busy: true,
+      disabled: true,
+    });
+  });
+
+  it('provides accessible input and error treatments', async () => {
+    const { getByLabelText, getByText } = await render(
+      <>
+        <PasswordInput accessibilityLabel="Password" value="secret" />
+        <ErrorMessage>Use a stronger password.</ErrorMessage>
+      </>,
+    );
+    expect(getByLabelText('Password')).toBeTruthy();
+    fireEvent.press(getByLabelText('Show password'));
+    expect(
+      getByText('Use a stronger password.').props.accessibilityLiveRegion,
+    ).toBe('polite');
+  });
+
+  it('renders a branded initials fallback and loading primitives', async () => {
+    const { getByLabelText } = await render(
+      <>
+        <Avatar name="Taylor Jordan" />
+        <LoadingState label="Loading profile" />
+        <Skeleton width="50%" />
+      </>,
+    );
+    expect(getByLabelText('Taylor Jordan avatar')).toBeTruthy();
+    expect(getByLabelText('Loading profile')).toBeTruthy();
+    expect(getByLabelText('Loading content')).toBeTruthy();
+  });
+});

--- a/apps/mobile/components/ui/avatar.tsx
+++ b/apps/mobile/components/ui/avatar.tsx
@@ -1,0 +1,37 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, typography } from './tokens';
+export function Avatar({
+  name,
+  size = 48,
+}: {
+  name?: string | null;
+  size?: number;
+}) {
+  const initials = (
+    name
+      ?.trim()
+      .split(/\s+/)
+      .map((part) => part[0])
+      .join('')
+      .slice(0, 2) || 'KF'
+  ).toUpperCase();
+  return (
+    <View
+      accessibilityLabel={`${name || 'KeylorFit'} avatar`}
+      style={[
+        styles.avatar,
+        { borderRadius: size / 2, height: size, width: size },
+      ]}
+    >
+      <Text style={styles.text}>{initials}</Text>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  avatar: {
+    alignItems: 'center',
+    backgroundColor: colors.training,
+    justifyContent: 'center',
+  },
+  text: { color: colors.onDark, ...typography.label },
+});

--- a/apps/mobile/components/ui/button.tsx
+++ b/apps/mobile/components/ui/button.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text } from 'react-native';
+import { colors, radii, spacing, touchTarget, typography } from './tokens';
+
+type ButtonProps = {
+  accessibilityLabel?: string;
+  children: ReactNode;
+  disabled?: boolean;
+  loading?: boolean;
+  onPress: () => void;
+  variant?: 'primary' | 'secondary' | 'destructive';
+};
+export function Button({
+  accessibilityLabel,
+  children,
+  disabled = false,
+  loading = false,
+  onPress,
+  variant = 'primary',
+}: ButtonProps) {
+  const inactive = disabled || loading;
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ busy: loading, disabled: inactive }}
+      disabled={inactive}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.base,
+        styles[variant],
+        inactive && styles.disabled,
+        pressed && !inactive && styles.pressed,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator
+          color={variant === 'secondary' ? colors.training : colors.onDark}
+        />
+      ) : (
+        <Text
+          style={[
+            styles.label,
+            variant === 'secondary' && styles.secondaryLabel,
+          ]}
+        >
+          {children}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+const styles = StyleSheet.create({
+  base: {
+    alignItems: 'center',
+    borderRadius: radii.sm,
+    justifyContent: 'center',
+    minHeight: touchTarget,
+    paddingHorizontal: spacing.lg,
+  },
+  destructive: { backgroundColor: colors.error },
+  disabled: { backgroundColor: colors.disabled },
+  label: { color: colors.onDark, ...typography.label },
+  pressed: { opacity: 0.86 },
+  primary: { backgroundColor: colors.training },
+  secondary: {
+    backgroundColor: colors.surface,
+    borderColor: colors.training,
+    borderWidth: 1,
+  },
+  secondaryLabel: { color: colors.training },
+});

--- a/apps/mobile/components/ui/button.tsx
+++ b/apps/mobile/components/ui/button.tsx
@@ -19,9 +19,11 @@ export function Button({
   variant = 'primary',
 }: ButtonProps) {
   const inactive = disabled || loading;
+  const resolvedAccessibilityLabel =
+    accessibilityLabel ?? (typeof children === 'string' ? children : undefined);
   return (
     <Pressable
-      accessibilityLabel={accessibilityLabel}
+      accessibilityLabel={resolvedAccessibilityLabel}
       accessibilityRole="button"
       accessibilityState={{ busy: loading, disabled: inactive }}
       disabled={inactive}

--- a/apps/mobile/components/ui/card.tsx
+++ b/apps/mobile/components/ui/card.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { colors, elevation, radii, spacing } from './tokens';
+export function Card({ children }: PropsWithChildren) {
+  return <View style={styles.card}>{children}</View>;
+}
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    padding: spacing.lg,
+    ...elevation.card,
+  },
+});

--- a/apps/mobile/components/ui/feedback.tsx
+++ b/apps/mobile/components/ui/feedback.tsx
@@ -1,0 +1,53 @@
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing, typography } from './tokens';
+export function LoadingState({ label = 'Loading…' }: { label?: string }) {
+  return (
+    <View accessibilityLiveRegion="polite" style={styles.loading}>
+      <ActivityIndicator accessibilityLabel={label} color={colors.training} />
+      <Text style={styles.muted}>{label}</Text>
+    </View>
+  );
+}
+export function Skeleton({
+  width = '100%',
+}: {
+  width?: number | `${number}%`;
+}) {
+  return (
+    <View
+      accessibilityLabel="Loading content"
+      style={[styles.skeleton, { width }]}
+    />
+  );
+}
+export function EmptyState({ body, title }: { body: string; title: string }) {
+  return (
+    <View style={styles.empty}>
+      <Text accessibilityRole="header" style={styles.title}>
+        {title}
+      </Text>
+      <Text style={styles.muted}>{body}</Text>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  empty: { alignItems: 'center', paddingVertical: spacing.xxxl },
+  loading: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacing.xl,
+  },
+  muted: {
+    color: colors.textMuted,
+    marginTop: spacing.sm,
+    textAlign: 'center',
+    ...typography.body,
+  },
+  skeleton: {
+    backgroundColor: colors.surfaceSubtle,
+    borderRadius: radii.sm,
+    height: 16,
+  },
+  title: { color: colors.text, ...typography.section },
+});

--- a/apps/mobile/components/ui/form.tsx
+++ b/apps/mobile/components/ui/form.tsx
@@ -1,0 +1,77 @@
+import { type ReactNode, useState } from 'react';
+import type { TextInputProps } from 'react-native';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { colors, radii, spacing, touchTarget, typography } from './tokens';
+export function FieldLabel({ children }: { children: string }) {
+  return <Text style={styles.label}>{children}</Text>;
+}
+export function ErrorMessage({ children }: { children: ReactNode }) {
+  return (
+    <Text accessibilityLiveRegion="polite" style={styles.error}>
+      {children}
+    </Text>
+  );
+}
+export function FormInput(props: TextInputProps) {
+  return (
+    <TextInput
+      placeholderTextColor={colors.textMuted}
+      style={styles.input}
+      {...props}
+    />
+  );
+}
+export function PasswordInput(props: Omit<TextInputProps, 'secureTextEntry'>) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <View style={styles.passwordRow}>
+      <TextInput
+        placeholderTextColor={colors.textMuted}
+        secureTextEntry={!visible}
+        style={[styles.input, styles.passwordInput]}
+        {...props}
+      />
+      <Pressable
+        accessibilityLabel={visible ? 'Hide password' : 'Show password'}
+        accessibilityRole="button"
+        onPress={() => setVisible((current) => !current)}
+        style={styles.visibility}
+      >
+        <Text style={styles.visibilityText}>{visible ? 'Hide' : 'Show'}</Text>
+      </Pressable>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  error: { color: colors.error, marginTop: spacing.sm, ...typography.caption },
+  input: {
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
+    borderRadius: radii.sm,
+    borderWidth: 1,
+    color: colors.text,
+    marginTop: spacing.sm,
+    minHeight: touchTarget,
+    paddingHorizontal: spacing.md,
+    ...typography.body,
+  },
+  label: { color: colors.text, marginTop: spacing.lg, ...typography.label },
+  passwordInput: { flex: 1, marginTop: 0 },
+  passwordRow: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
+    borderRadius: radii.sm,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginTop: spacing.sm,
+    overflow: 'hidden',
+  },
+  visibility: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: touchTarget,
+    minWidth: touchTarget,
+  },
+  visibilityText: { color: colors.training, ...typography.label },
+});

--- a/apps/mobile/components/ui/screen.tsx
+++ b/apps/mobile/components/ui/screen.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithChildren } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { colors, spacing } from './tokens';
+
+type ScreenProps = PropsWithChildren<{ scroll?: boolean; testID?: string }>;
+
+export function Screen({ children, scroll = false, testID }: ScreenProps) {
+  const content = scroll ? (
+    <ScrollView contentContainerStyle={styles.scroll}>{children}</ScrollView>
+  ) : (
+    <View style={styles.content}>{children}</View>
+  );
+  return (
+    <SafeAreaView edges={['top', 'bottom']} style={styles.safe} testID={testID}>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: 'padding', default: undefined })}
+        style={styles.flex}
+      >
+        {content}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  safe: { backgroundColor: colors.canvas, flex: 1 },
+  content: { flex: 1, padding: spacing.xl },
+  scroll: { flexGrow: 1, padding: spacing.xl },
+});

--- a/apps/mobile/components/ui/section-heading.tsx
+++ b/apps/mobile/components/ui/section-heading.tsx
@@ -1,0 +1,28 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing, typography } from './tokens';
+export function SectionHeading({
+  detail,
+  title,
+}: {
+  detail?: string;
+  title: string;
+}) {
+  return (
+    <View style={styles.row}>
+      <Text accessibilityRole="header" style={styles.title}>
+        {title}
+      </Text>
+      {detail ? <Text style={styles.detail}>{detail}</Text> : null}
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  detail: { color: colors.training, ...typography.caption },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: spacing.md,
+  },
+  title: { color: colors.text, ...typography.section },
+});

--- a/apps/mobile/components/ui/tokens.ts
+++ b/apps/mobile/components/ui/tokens.ts
@@ -1,0 +1,51 @@
+export const colors = {
+  canvas: '#F7F9FC',
+  surface: '#FFFFFF',
+  surfaceSubtle: '#EEF4FA',
+  text: '#101B2D',
+  textMuted: '#59677B',
+  border: '#D7E0EB',
+  training: '#0758F6',
+  trainingPressed: '#0047CD',
+  progress: '#11BFAF',
+  strength: '#7147E8',
+  warning: '#D97706',
+  error: '#D83B3B',
+  errorSurface: '#FFF2F1',
+  disabled: '#AEB9C7',
+  onDark: '#FFFFFF',
+  workoutCanvas: '#061525',
+  workoutSurface: '#0D243A',
+  workoutText: '#F8FBFF',
+  workoutMuted: '#A9BED3',
+  workoutAction: '#25BEEB',
+} as const;
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
+  xxxl: 48,
+} as const;
+export const radii = { sm: 8, md: 12, lg: 18, pill: 999 } as const;
+export const typography = {
+  display: { fontSize: 36, fontWeight: '800' as const, lineHeight: 42 },
+  title: { fontSize: 28, fontWeight: '800' as const, lineHeight: 34 },
+  section: { fontSize: 18, fontWeight: '700' as const, lineHeight: 24 },
+  body: { fontSize: 16, fontWeight: '400' as const, lineHeight: 23 },
+  label: { fontSize: 14, fontWeight: '700' as const, lineHeight: 20 },
+  caption: { fontSize: 13, fontWeight: '500' as const, lineHeight: 18 },
+} as const;
+export const touchTarget = 48;
+export const elevation = {
+  card: {
+    elevation: 2,
+    shadowColor: '#10243D',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+  },
+} as const;

--- a/docs/design-docs/KEYLORFIT_VISUAL_FOUNDATION.md
+++ b/docs/design-docs/KEYLORFIT_VISUAL_FOUNDATION.md
@@ -8,11 +8,11 @@ This document is the implementation contract for KeylorFit's visual foundation. 
 
 The approved broader product-direction reference is committed at:
 
-`docs/design-docs/keylorfit-ui-reference/keylorfit-ui-foundation-v1.jpg`
+`docs/design-docs/keylorfit-ui-reference/keylorfit-ui-foundation-v1.png`
 
 The approved **current M1 / UX-001 implementation reference** is committed at:
 
-`docs/design-docs/keylorfit-ui-reference/keylorfit-m1-reference-v1.jpg`
+`docs/design-docs/keylorfit-ui-reference/keylorfit-m1-reference-v1.png`
 
 Both images are **directional visual references**, not pixel-perfect screenshot specifications and not commitments that every future feature shown in a concept exists in the current milestone. Where generated mockup text or data conflicts with product/domain contracts, the product/domain contracts win.
 
@@ -247,8 +247,8 @@ The M1 mockup may show illustrative items that are **not** current requirements 
 
 For every visual implementation PR touching this foundation:
 
-- open `keylorfit-ui-foundation-v1.jpg` before coding
-- open `keylorfit-m1-reference-v1.jpg` before coding when implementing #51/current M1 surfaces
+- open `keylorfit-ui-foundation-v1.png` before coding
+- open `keylorfit-m1-reference-v1.png` before coding when implementing #51/current M1 surfaces
 - compare the rendered phone UI against the relevant region of the M1 reference during implementation
 - preserve hierarchy, density, imagery treatment, navigation character and mode distinction
 - do not blindly reproduce generated text, fake data, unsupported auth providers or impossible details

--- a/docs/design-docs/MOBILE_UI_FOUNDATION.md
+++ b/docs/design-docs/MOBILE_UI_FOUNDATION.md
@@ -1,0 +1,11 @@
+# KeylorFit mobile UI foundation
+
+The reusable light-mode foundation for M1 lives in `apps/mobile/components/ui/`.
+
+- `tokens.ts` defines semantic application and future active-workout roles, typography, spacing, geometry, elevation and touch targets.
+- `screen.tsx`, `card.tsx`, `section-heading.tsx` and `avatar.tsx` supply structural surfaces.
+- `button.tsx`, `form.tsx` and `feedback.tsx` supply controls and accessible loading, validation, empty and skeleton states.
+
+Future M2 screens should compose these primitives and use semantic tokens rather than raw color values. Add a new primitive only when it is useful on more than one surface. The future five-item navigation (`Home`, `Progress`, `Train`, `Social`, `Profile`) should reuse the compact action treatment, but routes must only be exposed when functional.
+
+The standard application remains light-only. The workout color roles are reserved for the later active-workout immersive mode; global dark mode is intentionally deferred.

--- a/docs/design-docs/keylorfit-ui-reference/README.md
+++ b/docs/design-docs/keylorfit-ui-reference/README.md
@@ -6,7 +6,7 @@ This directory stores Product Owner-approved visual references used while implem
 
 Canonical file:
 
-`keylorfit-ui-foundation-v1.jpg`
+`keylorfit-ui-foundation-v1.png`
 
 This is the approved concept board covering the broader KeylorFit visual language for Home, active workout, Progress, Training Hub, Social/Ranking and representative future product surfaces.
 
@@ -14,7 +14,7 @@ This is the approved concept board covering the broader KeylorFit visual languag
 
 Canonical file:
 
-`keylorfit-m1-reference-v1.jpg`
+`keylorfit-m1-reference-v1.png`
 
 This board is the Product Owner-approved implementation reference for the current UX-001 scope. It covers:
 


### PR DESCRIPTION
## Status
**CLOSED WITHOUT MERGE — physical Android visual acceptance failed.**

This PR proved that the underlying code-quality approach can stay green, but the rendered M1 experience was materially too far from the Product Owner-approved board. UX-001 remains open in #51.

## Why this PR is closed
- Welcome did not reproduce the approved high-energy dark photographic hero, palette or visual hierarchy.
- Sign in / Sign up remained too generic relative to the approved M1 board.
- The five-destination authenticated shell belongs to separate UX-002 / #67.
- Real Google/Apple auth belongs to IDN-008 / #66.
- Product Owner requested a smaller, design-parity-first implementation slice rather than continuing a broad 18-file PR.

## What may be reused conceptually
Only neutral engineering techniques that still fit the approved design: semantic tokens, safe areas, accessibility/touch-target handling, small primitives, and preserved auth/profile behavior. Do not treat this PR's visual composition as an accepted reference.

## Validation history
Final HEAD had Backend CI, Mobile CI and Database Migration CI green, but CI success did not satisfy the visual acceptance gate.

Refs #51.