### PR TITLE
[SUPERSEDED by #74] feat(mobile): add password recovery flow

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -96,6 +96,26 @@ for this test.
 For an expired or previously used email link, KeylorForge should stay signed out,
 show a safe request-a-new-email message, and provide a route back to sign in.
 
+### Physical Android password-recovery acceptance
+
+Before testing, the Supabase development project's Auth Redirect URLs must also
+contain the exact `keylorforge://auth/recovery` callback. On an installed Android
+development build:
+
+1. Open **Forgot your password?** from sign-in and request recovery for a
+   disposable account.
+2. Tap the received recovery link. Android should open KeylorForge at
+   `keylorforge://auth/recovery` and show the new-password form, never the
+   authenticated home screen.
+3. Enter and confirm a new password, then confirm the app returns to sign-in.
+   Sign in successfully with the new password.
+4. Repeat with an expired or used link. The app must remain out of protected
+   navigation, show a safe recovery error, and let the user request another
+   email.
+
+Do not capture or share the recovery email URL, authorization code, access
+token, refresh token, or password.
+
 ## Validation
 
 ```sh

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -58,7 +58,9 @@ describe('PasswordRecoveryRoute', () => {
     fireEvent.press(view.getByText('Send recovery link'));
 
     await waitFor(() => {
-      expect(requestPasswordRecovery).toHaveBeenCalledWith('person@example.com');
+      expect(requestPasswordRecovery).toHaveBeenCalledWith(
+        'person@example.com',
+      );
     });
     expect(
       await view.findByText(

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -41,7 +41,7 @@ describe('PasswordRecoveryRoute', () => {
     } as unknown as ReturnType<typeof useAuth>);
   });
 
-  it('validates the email before requesting recovery', async () => {
+  it('validates the email, then submits without revealing account existence', async () => {
     const view = await render(<PasswordRecoveryRoute />);
 
     fireEvent.changeText(view.getByLabelText('Email'), 'not-an-email');
@@ -49,10 +49,6 @@ describe('PasswordRecoveryRoute', () => {
 
     expect(await view.findByText('Enter a valid email address.')).toBeTruthy();
     expect(requestPasswordRecovery).not.toHaveBeenCalled();
-  });
-
-  it('submits a valid email and shows a non-enumerating success message', async () => {
-    const view = await render(<PasswordRecoveryRoute />);
 
     fireEvent.changeText(view.getByLabelText('Email'), 'person@example.com');
     fireEvent.press(view.getByText('Send recovery link'));

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -1,4 +1,9 @@
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 
 import PasswordRecoveryRoute from '../password-recovery';
@@ -44,14 +49,25 @@ describe('PasswordRecoveryRoute', () => {
   it('validates the email, then submits without revealing account existence', async () => {
     const view = await render(<PasswordRecoveryRoute />);
 
-    fireEvent.changeText(view.getByLabelText('Email'), 'not-an-email');
-    fireEvent.press(view.getByText('Send recovery link'));
+    await act(async () => {
+      fireEvent.changeText(view.getByLabelText('Email'), 'not-an-email');
+    });
+    await act(async () => {
+      fireEvent.press(view.getByText('Send recovery link'));
+    });
 
     expect(await view.findByText('Enter a valid email address.')).toBeTruthy();
     expect(requestPasswordRecovery).not.toHaveBeenCalled();
 
-    fireEvent.changeText(view.getByLabelText('Email'), 'person@example.com');
-    fireEvent.press(view.getByText('Send recovery link'));
+    await act(async () => {
+      fireEvent.changeText(view.getByLabelText('Email'), 'person@example.com');
+    });
+    await waitFor(() => {
+      expect(view.getByDisplayValue('person@example.com')).toBeTruthy();
+    });
+    await act(async () => {
+      fireEvent.press(view.getByText('Send recovery link'));
+    });
 
     await waitFor(() => {
       expect(requestPasswordRecovery).toHaveBeenCalledWith(

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+import PasswordRecoveryRoute from '../password-recovery';
+import { useAuth } from '@/lib/auth/auth-provider';
+
+const requestPasswordRecovery = jest.fn();
+const mockedUseAuth = jest.mocked(useAuth);
+
+jest.mock('@/lib/auth/auth-provider', () => ({ useAuth: jest.fn() }));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children, href }: { children: ReactNode; href: string }) => {
+    const { Text: MockText, View: MockView } =
+      jest.requireActual('react-native');
+
+    return (
+      <MockView>
+        <MockText>{href}</MockText>
+        {children}
+      </MockView>
+    );
+  },
+  Redirect: ({ href }: { href: string }) => {
+    const { Text: MockText } = jest.requireActual('react-native');
+
+    return <MockText testID="redirect">{href}</MockText>;
+  },
+}));
+
+describe('PasswordRecoveryRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requestPasswordRecovery.mockResolvedValue({});
+    mockedUseAuth.mockReturnValue(
+      ({
+        confirmationEmail: null,
+        feedback: null,
+        phase: 'signedOut',
+        requestPasswordRecovery,
+        session: null,
+      }) as unknown as ReturnType<typeof useAuth>,
+    );
+  });
+
+  it('validates the email before requesting recovery', async () => {
+    const view = render(<PasswordRecoveryRoute />);
+
+    fireEvent.changeText(view.getByLabelText('Email'), 'not-an-email');
+    fireEvent.press(view.getByText('Send recovery link'));
+
+    expect(await view.findByText('Enter a valid email address.')).toBeTruthy();
+    expect(requestPasswordRecovery).not.toHaveBeenCalled();
+  });
+
+  it('submits a valid email and shows a non-enumerating success message', async () => {
+    const view = render(<PasswordRecoveryRoute />);
+
+    fireEvent.changeText(view.getByLabelText('Email'), 'person@example.com');
+    fireEvent.press(view.getByText('Send recovery link'));
+
+    await waitFor(() => {
+      expect(requestPasswordRecovery).toHaveBeenCalledWith(
+        'person@example.com',
+      );
+    });
+    expect(
+      await view.findByText(
+        'If an account matches that email address, we sent a password recovery link. Open it on this device.',
+      ),
+    ).toBeTruthy();
+    expect(view.queryByTestId('redirect')).toBeNull();
+  });
+});

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -32,15 +32,13 @@ describe('PasswordRecoveryRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     requestPasswordRecovery.mockResolvedValue({});
-    mockedUseAuth.mockReturnValue(
-      ({
-        confirmationEmail: null,
-        feedback: null,
-        phase: 'signedOut',
-        requestPasswordRecovery,
-        session: null,
-      }) as unknown as ReturnType<typeof useAuth>,
-    );
+    mockedUseAuth.mockReturnValue({
+      confirmationEmail: null,
+      feedback: null,
+      phase: 'signedOut',
+      requestPasswordRecovery,
+      session: null,
+    } as unknown as ReturnType<typeof useAuth>);
   });
 
   it('validates the email before requesting recovery', async () => {
@@ -60,9 +58,7 @@ describe('PasswordRecoveryRoute', () => {
     fireEvent.press(view.getByText('Send recovery link'));
 
     await waitFor(() => {
-      expect(requestPasswordRecovery).toHaveBeenCalledWith(
-        'person@example.com',
-      );
+      expect(requestPasswordRecovery).toHaveBeenCalledWith('person@example.com');
     });
     expect(
       await view.findByText(

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -42,7 +42,7 @@ describe('PasswordRecoveryRoute', () => {
   });
 
   it('validates the email before requesting recovery', async () => {
-    const view = render(<PasswordRecoveryRoute />);
+    const view = await render(<PasswordRecoveryRoute />);
 
     fireEvent.changeText(view.getByLabelText('Email'), 'not-an-email');
     fireEvent.press(view.getByText('Send recovery link'));
@@ -52,7 +52,7 @@ describe('PasswordRecoveryRoute', () => {
   });
 
   it('submits a valid email and shows a non-enumerating success message', async () => {
-    const view = render(<PasswordRecoveryRoute />);
+    const view = await render(<PasswordRecoveryRoute />);
 
     fireEvent.changeText(view.getByLabelText('Email'), 'person@example.com');
     fireEvent.press(view.getByText('Send recovery link'));

--- a/apps/mobile/app/__tests__/password-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/password-recovery.test.tsx
@@ -1,9 +1,4 @@
-import {
-  act,
-  fireEvent,
-  render,
-  waitFor,
-} from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 
 import PasswordRecoveryRoute from '../password-recovery';

--- a/apps/mobile/app/__tests__/sign-in-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/sign-in-recovery.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+import SignInRoute from '../sign-in';
+import { useAuth } from '@/lib/auth/auth-provider';
+import { useLocalSearchParams } from 'expo-router';
+
+const mockedUseAuth = jest.mocked(useAuth);
+const mockedUseLocalSearchParams = jest.mocked(useLocalSearchParams);
+const signIn = jest.fn();
+
+jest.mock('@/lib/auth/auth-provider', () => ({ useAuth: jest.fn() }));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children, href }: { children: ReactNode; href: string }) => {
+    const { Text: MockText, View: MockView } =
+      jest.requireActual('react-native');
+
+    return (
+      <MockView testID={`link:${href}`}>
+        <MockText>{href}</MockText>
+        {children}
+      </MockView>
+    );
+  },
+  Redirect: ({ href }: { href: string }) => {
+    const { Text: MockText } = jest.requireActual('react-native');
+
+    return <MockText testID="redirect">{href}</MockText>;
+  },
+  useLocalSearchParams: jest.fn(),
+}));
+
+describe('SignInRoute recovery entry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseLocalSearchParams.mockReturnValue({ passwordUpdated: 'true' });
+    mockedUseAuth.mockReturnValue(
+      ({
+        confirmationEmail: null,
+        feedback: null,
+        phase: 'signedOut',
+        session: null,
+        signIn,
+      }) as unknown as ReturnType<typeof useAuth>,
+    );
+  });
+
+  it('exposes password recovery and confirms a completed password update', () => {
+    const view = render(<SignInRoute />);
+
+    expect(
+      view.getByText('Password updated. Sign in with your new password.'),
+    ).toBeTruthy();
+    expect(view.getByTestId('link:/password-recovery')).toBeTruthy();
+    expect(view.getByText('/password-recovery')).toBeTruthy();
+    expect(view.queryByTestId('redirect')).toBeNull();
+  });
+});

--- a/apps/mobile/app/__tests__/sign-in-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/sign-in-recovery.test.tsx
@@ -35,15 +35,13 @@ describe('SignInRoute recovery entry', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseLocalSearchParams.mockReturnValue({ passwordUpdated: 'true' });
-    mockedUseAuth.mockReturnValue(
-      ({
-        confirmationEmail: null,
-        feedback: null,
-        phase: 'signedOut',
-        session: null,
-        signIn,
-      }) as unknown as ReturnType<typeof useAuth>,
-    );
+    mockedUseAuth.mockReturnValue({
+      confirmationEmail: null,
+      feedback: null,
+      phase: 'signedOut',
+      session: null,
+      signIn,
+    } as unknown as ReturnType<typeof useAuth>);
   });
 
   it('exposes password recovery and confirms a completed password update', () => {

--- a/apps/mobile/app/__tests__/sign-in-recovery.test.tsx
+++ b/apps/mobile/app/__tests__/sign-in-recovery.test.tsx
@@ -44,8 +44,8 @@ describe('SignInRoute recovery entry', () => {
     } as unknown as ReturnType<typeof useAuth>);
   });
 
-  it('exposes password recovery and confirms a completed password update', () => {
-    const view = render(<SignInRoute />);
+  it('exposes password recovery and confirms a completed password update', async () => {
+    const view = await render(<SignInRoute />);
 
     expect(
       view.getByText('Password updated. Sign in with your new password.'),

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from 'expo-router';
 import { useState } from 'react';
 
 import { AuthProvider } from '@/lib/auth/auth-provider';
+import { RecoveryLinkProvider } from '@/lib/auth/recovery-link-provider';
 
 export default function RootLayout() {
   const [queryClient] = useState(() => new QueryClient());
@@ -10,7 +11,9 @@ export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <Stack screenOptions={{ headerShown: false }} />
+        <RecoveryLinkProvider>
+          <Stack screenOptions={{ headerShown: false }} />
+        </RecoveryLinkProvider>
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -1,18 +1,17 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useLocalSearchParams } from 'expo-router';
 
 import RecoveryCallbackRoute from '../recovery';
 import { useAuth } from '@/lib/auth/auth-provider';
-import { useLinkingURL } from 'expo-linking';
 
 const mockReplace = jest.fn();
 const consumeRecoveryCallback = jest.fn();
 const updateRecoveryPassword = jest.fn();
 const mockedUseAuth = jest.mocked(useAuth);
-const mockedUseLinkingURL = jest.mocked(useLinkingURL);
-
-jest.mock('expo-linking', () => ({ useLinkingURL: jest.fn() }));
+const mockedUseLocalSearchParams = jest.mocked(useLocalSearchParams);
 
 jest.mock('expo-router', () => ({
+  useLocalSearchParams: jest.fn(),
   useRouter: () => ({ replace: mockReplace }),
 }));
 
@@ -21,9 +20,9 @@ jest.mock('@/lib/auth/auth-provider', () => ({ useAuth: jest.fn() }));
 describe('RecoveryCallbackRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseLinkingURL.mockReturnValue(
-      'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
-    );
+    mockedUseLocalSearchParams.mockReturnValue({
+      '#': 'access_token=access-token&refresh_token=refresh-token&type=recovery',
+    });
     updateRecoveryPassword.mockResolvedValue({});
   });
 
@@ -40,6 +39,35 @@ describe('RecoveryCallbackRoute', () => {
     await waitFor(() => {
       expect(consumeRecoveryCallback).toHaveBeenCalledWith(
         'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
+      );
+    });
+  });
+
+  it('consumes a second recovery link from the current route hash', async () => {
+    consumeRecoveryCallback.mockResolvedValue({});
+    mockedUseAuth.mockReturnValue({
+      consumeRecoveryCallback,
+      phase: 'signedOut',
+      updateRecoveryPassword,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    const view = await render(<RecoveryCallbackRoute />);
+
+    await waitFor(() => {
+      expect(consumeRecoveryCallback).toHaveBeenCalledWith(
+        'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
+      );
+    });
+
+    mockedUseLocalSearchParams.mockReturnValue({
+      '#': 'access_token=second-access-token&refresh_token=second-refresh-token&type=recovery',
+    });
+    await view.rerender(<RecoveryCallbackRoute />);
+
+    await waitFor(() => {
+      expect(consumeRecoveryCallback).toHaveBeenCalledTimes(2);
+      expect(consumeRecoveryCallback).toHaveBeenLastCalledWith(
+        'keylorforge://auth/recovery#access_token=second-access-token&refresh_token=second-refresh-token&type=recovery',
       );
     });
   });

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -27,6 +27,23 @@ describe('RecoveryCallbackRoute', () => {
     updateRecoveryPassword.mockResolvedValue({});
   });
 
+  it('consumes the recovery callback while auth restoration is still in progress', async () => {
+    consumeRecoveryCallback.mockResolvedValue({});
+    mockedUseAuth.mockReturnValue({
+      consumeRecoveryCallback,
+      phase: 'restoring',
+      updateRecoveryPassword,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    await render(<RecoveryCallbackRoute />);
+
+    await waitFor(() => {
+      expect(consumeRecoveryCallback).toHaveBeenCalledWith(
+        'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
+      );
+    });
+  });
+
   it('shows a safe callback failure and lets the user request another email', async () => {
     consumeRecoveryCallback.mockResolvedValue({
       error:

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -26,23 +26,6 @@ describe('RecoveryCallbackRoute', () => {
     updateRecoveryPassword.mockResolvedValue({});
   });
 
-  it('consumes the recovery callback while auth restoration is still in progress', async () => {
-    consumeRecoveryCallback.mockResolvedValue({});
-    mockedUseAuth.mockReturnValue({
-      consumeRecoveryCallback,
-      phase: 'restoring',
-      updateRecoveryPassword,
-    } as unknown as ReturnType<typeof useAuth>);
-
-    await render(<RecoveryCallbackRoute />);
-
-    await waitFor(() => {
-      expect(consumeRecoveryCallback).toHaveBeenCalledWith(
-        'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
-      );
-    });
-  });
-
   it('consumes a second recovery link from the current route hash', async () => {
     consumeRecoveryCallback.mockResolvedValue({});
     mockedUseAuth.mockReturnValue({

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -157,9 +157,7 @@ describe('RecoveryCallbackRoute', () => {
     const view = await render(<RecoveryCallbackRoute />);
 
     await act(async () => {
-      fireEvent.press(
-        view.getByText('Cancel recovery and return to sign in'),
-      );
+      fireEvent.press(view.getByText('Cancel recovery and return to sign in'));
     });
 
     expect(invalidateSession).toHaveBeenCalledTimes(1);

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -1,35 +1,43 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
-import { useLocalSearchParams } from 'expo-router';
 
 import RecoveryCallbackRoute from '../recovery';
 import { useAuth } from '@/lib/auth/auth-provider';
+import { useRecoveryLink } from '@/lib/auth/recovery-link-provider';
 
 const mockReplace = jest.fn();
+const clearRecoveryLink = jest.fn();
 const consumeRecoveryCallback = jest.fn();
+const invalidateSession = jest.fn();
 const updateRecoveryPassword = jest.fn();
 const mockedUseAuth = jest.mocked(useAuth);
-const mockedUseLocalSearchParams = jest.mocked(useLocalSearchParams);
+const mockedUseRecoveryLink = jest.mocked(useRecoveryLink);
 
 jest.mock('expo-router', () => ({
-  useLocalSearchParams: jest.fn(),
   useRouter: () => ({ replace: mockReplace }),
 }));
 
 jest.mock('@/lib/auth/auth-provider', () => ({ useAuth: jest.fn() }));
+jest.mock('@/lib/auth/recovery-link-provider', () => ({
+  useRecoveryLink: jest.fn(),
+}));
 
 describe('RecoveryCallbackRoute', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseLocalSearchParams.mockReturnValue({
-      '#': 'access_token=access-token&refresh_token=refresh-token&type=recovery',
+    invalidateSession.mockResolvedValue(undefined);
+    mockedUseRecoveryLink.mockReturnValue({
+      clearRecoveryLink,
+      recoveryUrl:
+        'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
     });
     updateRecoveryPassword.mockResolvedValue({});
   });
 
-  it('consumes a second recovery link from the current route hash', async () => {
+  it('consumes a newer recovery link retained above the route', async () => {
     consumeRecoveryCallback.mockResolvedValue({});
     mockedUseAuth.mockReturnValue({
       consumeRecoveryCallback,
+      invalidateSession,
       phase: 'signedOut',
       updateRecoveryPassword,
     } as unknown as ReturnType<typeof useAuth>);
@@ -40,10 +48,15 @@ describe('RecoveryCallbackRoute', () => {
       expect(consumeRecoveryCallback).toHaveBeenCalledWith(
         'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
       );
+      expect(clearRecoveryLink).toHaveBeenCalledWith(
+        'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
+      );
     });
 
-    mockedUseLocalSearchParams.mockReturnValue({
-      '#': 'access_token=second-access-token&refresh_token=second-refresh-token&type=recovery',
+    mockedUseRecoveryLink.mockReturnValue({
+      clearRecoveryLink,
+      recoveryUrl:
+        'keylorforge://auth/recovery#access_token=second-access-token&refresh_token=second-refresh-token&type=recovery',
     });
     await view.rerender(<RecoveryCallbackRoute />);
 
@@ -62,6 +75,7 @@ describe('RecoveryCallbackRoute', () => {
     });
     mockedUseAuth.mockReturnValue({
       consumeRecoveryCallback,
+      invalidateSession,
       phase: 'signedOut',
       updateRecoveryPassword,
     } as unknown as ReturnType<typeof useAuth>);
@@ -87,6 +101,7 @@ describe('RecoveryCallbackRoute', () => {
     consumeRecoveryCallback.mockResolvedValue({});
     mockedUseAuth.mockReturnValue({
       consumeRecoveryCallback,
+      invalidateSession,
       phase: 'recovery',
       updateRecoveryPassword,
     } as unknown as ReturnType<typeof useAuth>);
@@ -129,5 +144,25 @@ describe('RecoveryCallbackRoute', () => {
         pathname: '/sign-in',
       });
     });
+  });
+
+  it('lets the user abandon a persisted recovery session safely', async () => {
+    mockedUseAuth.mockReturnValue({
+      consumeRecoveryCallback,
+      invalidateSession,
+      phase: 'recovery',
+      updateRecoveryPassword,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    const view = await render(<RecoveryCallbackRoute />);
+
+    await act(async () => {
+      fireEvent.press(
+        view.getByText('Cancel recovery and return to sign in'),
+      );
+    });
+
+    expect(invalidateSession).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/sign-in');
   });
 });

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -93,7 +93,7 @@ describe('RecoveryCallbackRoute', () => {
       );
     });
     await waitFor(() => {
-      expect(view.getByDisplayValue('password123')).toBeTruthy();
+      expect(view.getAllByDisplayValue('password123')).toHaveLength(2);
     });
     await act(async () => {
       fireEvent.press(view.getByText('Update password'));

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -38,7 +38,7 @@ describe('RecoveryCallbackRoute', () => {
       updateRecoveryPassword,
     } as unknown as ReturnType<typeof useAuth>);
 
-    const view = render(<RecoveryCallbackRoute />);
+    const view = await render(<RecoveryCallbackRoute />);
 
     await waitFor(() => {
       expect(consumeRecoveryCallback).toHaveBeenCalledTimes(1);
@@ -61,7 +61,7 @@ describe('RecoveryCallbackRoute', () => {
       updateRecoveryPassword,
     } as unknown as ReturnType<typeof useAuth>);
 
-    const view = render(<RecoveryCallbackRoute />);
+    const view = await render(<RecoveryCallbackRoute />);
 
     fireEvent.changeText(view.getByLabelText('New password'), 'password123');
     fireEvent.changeText(

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -1,9 +1,4 @@
-import {
-  act,
-  fireEvent,
-  render,
-  waitFor,
-} from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import RecoveryCallbackRoute from '../recovery';
 import { useAuth } from '@/lib/auth/auth-provider';

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import RecoveryCallbackRoute from '../recovery';
+import { useAuth } from '@/lib/auth/auth-provider';
+import { useLinkingURL } from 'expo-linking';
+
+const mockReplace = jest.fn();
+const consumeRecoveryCallback = jest.fn();
+const updateRecoveryPassword = jest.fn();
+const mockedUseAuth = jest.mocked(useAuth);
+const mockedUseLinkingURL = jest.mocked(useLinkingURL);
+
+jest.mock('expo-linking', () => ({ useLinkingURL: jest.fn() }));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock('@/lib/auth/auth-provider', () => ({ useAuth: jest.fn() }));
+
+describe('RecoveryCallbackRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseLinkingURL.mockReturnValue(
+      'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
+    );
+    updateRecoveryPassword.mockResolvedValue({});
+  });
+
+  it('shows a safe callback failure and lets the user request another email', async () => {
+    consumeRecoveryCallback.mockResolvedValue({
+      error:
+        'This recovery link is no longer valid. Request a new recovery email and try again.',
+    });
+    mockedUseAuth.mockReturnValue(
+      ({
+        consumeRecoveryCallback,
+        phase: 'signedOut',
+        updateRecoveryPassword,
+      }) as unknown as ReturnType<typeof useAuth>,
+    );
+
+    const view = render(<RecoveryCallbackRoute />);
+
+    await waitFor(() => {
+      expect(consumeRecoveryCallback).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      await view.findByText(
+        'This recovery link is no longer valid. Request a new recovery email and try again.',
+      ),
+    ).toBeTruthy();
+
+    fireEvent.press(view.getByText('Request a new recovery email'));
+    expect(mockReplace).toHaveBeenCalledWith('/password-recovery');
+  });
+
+  it('validates matching passwords and returns to sign in after a successful update', async () => {
+    consumeRecoveryCallback.mockResolvedValue({});
+    mockedUseAuth.mockReturnValue(
+      ({
+        consumeRecoveryCallback,
+        phase: 'recovery',
+        updateRecoveryPassword,
+      }) as unknown as ReturnType<typeof useAuth>,
+    );
+
+    const view = render(<RecoveryCallbackRoute />);
+
+    fireEvent.changeText(view.getByLabelText('New password'), 'password123');
+    fireEvent.changeText(
+      view.getByLabelText('Confirm new password'),
+      'different123',
+    );
+    fireEvent.press(view.getByText('Update password'));
+
+    expect(await view.findByText('Passwords do not match.')).toBeTruthy();
+    expect(updateRecoveryPassword).not.toHaveBeenCalled();
+
+    fireEvent.changeText(
+      view.getByLabelText('Confirm new password'),
+      'password123',
+    );
+    fireEvent.press(view.getByText('Update password'));
+
+    await waitFor(() => {
+      expect(updateRecoveryPassword).toHaveBeenCalledWith('password123');
+      expect(mockReplace).toHaveBeenCalledWith({
+        params: { passwordUpdated: 'true' },
+        pathname: '/sign-in',
+      });
+    });
+  });
+});

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -1,4 +1,9 @@
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react-native';
 
 import RecoveryCallbackRoute from '../recovery';
 import { useAuth } from '@/lib/auth/auth-provider';
@@ -49,7 +54,9 @@ describe('RecoveryCallbackRoute', () => {
       ),
     ).toBeTruthy();
 
-    fireEvent.press(view.getByText('Request a new recovery email'));
+    await act(async () => {
+      fireEvent.press(view.getByText('Request a new recovery email'));
+    });
     expect(mockReplace).toHaveBeenCalledWith('/password-recovery');
   });
 
@@ -63,21 +70,34 @@ describe('RecoveryCallbackRoute', () => {
 
     const view = await render(<RecoveryCallbackRoute />);
 
-    fireEvent.changeText(view.getByLabelText('New password'), 'password123');
-    fireEvent.changeText(
-      view.getByLabelText('Confirm new password'),
-      'different123',
-    );
-    fireEvent.press(view.getByText('Update password'));
+    await act(async () => {
+      fireEvent.changeText(view.getByLabelText('New password'), 'password123');
+    });
+    await act(async () => {
+      fireEvent.changeText(
+        view.getByLabelText('Confirm new password'),
+        'different123',
+      );
+    });
+    await act(async () => {
+      fireEvent.press(view.getByText('Update password'));
+    });
 
     expect(await view.findByText('Passwords do not match.')).toBeTruthy();
     expect(updateRecoveryPassword).not.toHaveBeenCalled();
 
-    fireEvent.changeText(
-      view.getByLabelText('Confirm new password'),
-      'password123',
-    );
-    fireEvent.press(view.getByText('Update password'));
+    await act(async () => {
+      fireEvent.changeText(
+        view.getByLabelText('Confirm new password'),
+        'password123',
+      );
+    });
+    await waitFor(() => {
+      expect(view.getByDisplayValue('password123')).toBeTruthy();
+    });
+    await act(async () => {
+      fireEvent.press(view.getByText('Update password'));
+    });
 
     await waitFor(() => {
       expect(updateRecoveryPassword).toHaveBeenCalledWith('password123');

--- a/apps/mobile/app/auth/__tests__/recovery.test.tsx
+++ b/apps/mobile/app/auth/__tests__/recovery.test.tsx
@@ -32,13 +32,11 @@ describe('RecoveryCallbackRoute', () => {
       error:
         'This recovery link is no longer valid. Request a new recovery email and try again.',
     });
-    mockedUseAuth.mockReturnValue(
-      ({
-        consumeRecoveryCallback,
-        phase: 'signedOut',
-        updateRecoveryPassword,
-      }) as unknown as ReturnType<typeof useAuth>,
-    );
+    mockedUseAuth.mockReturnValue({
+      consumeRecoveryCallback,
+      phase: 'signedOut',
+      updateRecoveryPassword,
+    } as unknown as ReturnType<typeof useAuth>);
 
     const view = render(<RecoveryCallbackRoute />);
 
@@ -57,13 +55,11 @@ describe('RecoveryCallbackRoute', () => {
 
   it('validates matching passwords and returns to sign in after a successful update', async () => {
     consumeRecoveryCallback.mockResolvedValue({});
-    mockedUseAuth.mockReturnValue(
-      ({
-        consumeRecoveryCallback,
-        phase: 'recovery',
-        updateRecoveryPassword,
-      }) as unknown as ReturnType<typeof useAuth>,
-    );
+    mockedUseAuth.mockReturnValue({
+      consumeRecoveryCallback,
+      phase: 'recovery',
+      updateRecoveryPassword,
+    } as unknown as ReturnType<typeof useAuth>);
 
     const view = render(<RecoveryCallbackRoute />);
 

--- a/apps/mobile/app/auth/recovery.tsx
+++ b/apps/mobile/app/auth/recovery.tsx
@@ -18,7 +18,7 @@ export default function RecoveryCallbackRoute() {
   } | null>(null);
 
   useEffect(() => {
-    if (!callbackUrl || phase === 'restoring' || phase === 'recovery') {
+    if (!callbackUrl || phase === 'recovery') {
       return;
     }
 

--- a/apps/mobile/app/auth/recovery.tsx
+++ b/apps/mobile/app/auth/recovery.tsx
@@ -1,41 +1,44 @@
-import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
 import { Pressable, Text } from 'react-native';
 
 import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
 import { NewPasswordForm } from '@/components/auth/new-password-form';
 import { useAuth } from '@/lib/auth/auth-provider';
-import { RECOVERY_CALLBACK_URL } from '@/lib/auth/recovery-callback';
+import { useRecoveryLink } from '@/lib/auth/recovery-link-provider';
 
 export default function RecoveryCallbackRoute() {
-  const { '#': callbackHash } = useLocalSearchParams<{ '#': string }>();
   const router = useRouter();
-  const { consumeRecoveryCallback, phase, updateRecoveryPassword } = useAuth();
+  const {
+    consumeRecoveryCallback,
+    invalidateSession,
+    phase,
+    updateRecoveryPassword,
+  } = useAuth();
+  const { clearRecoveryLink, recoveryUrl } = useRecoveryLink();
   const [error, setError] = useState<string | null>(null);
-  const callbackUrl = useMemo(
-    () => (callbackHash ? `${RECOVERY_CALLBACK_URL}#${callbackHash}` : null),
-    [callbackHash],
-  );
   const callbackOperation = useRef<{
     promise: Promise<{ error?: string }>;
     url: string;
   } | null>(null);
 
   useEffect(() => {
-    if (!callbackUrl || phase === 'recovery') {
+    if (!recoveryUrl || phase === 'recovery') {
       return;
     }
 
     let active = true;
-    if (callbackOperation.current?.url !== callbackUrl) {
+    if (callbackOperation.current?.url !== recoveryUrl) {
       setError(null);
       callbackOperation.current = {
-        promise: consumeRecoveryCallback(callbackUrl),
-        url: callbackUrl,
+        promise: consumeRecoveryCallback(recoveryUrl),
+        url: recoveryUrl,
       };
     }
 
-    void callbackOperation.current.promise.then((result) => {
+    const operation = callbackOperation.current;
+    void operation.promise.then((result) => {
+      clearRecoveryLink(operation.url);
       if (active && result.error) {
         setError(result.error);
       }
@@ -44,7 +47,7 @@ export default function RecoveryCallbackRoute() {
     return () => {
       active = false;
     };
-  }, [callbackUrl, consumeRecoveryCallback, phase]);
+  }, [clearRecoveryLink, consumeRecoveryCallback, phase, recoveryUrl]);
 
   const updatePassword = async (password: string) => {
     const result = await updateRecoveryPassword(password);
@@ -57,6 +60,11 @@ export default function RecoveryCallbackRoute() {
     return result;
   };
 
+  const cancelRecovery = async () => {
+    await invalidateSession();
+    router.replace('/sign-in');
+  };
+
   const returnToRequest = () => router.replace('/password-recovery');
 
   if (phase === 'recovery') {
@@ -66,6 +74,15 @@ export default function RecoveryCallbackRoute() {
         title="Set new password"
       >
         <NewPasswordForm onSubmit={updatePassword} />
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => void cancelRecovery()}
+          style={authScreenStyles.footerAction}
+        >
+          <Text style={authScreenStyles.footerText}>
+            Cancel recovery and return to sign in
+          </Text>
+        </Pressable>
       </AuthScreen>
     );
   }

--- a/apps/mobile/app/auth/recovery.tsx
+++ b/apps/mobile/app/auth/recovery.tsx
@@ -1,0 +1,86 @@
+import { useRouter } from 'expo-router';
+import { useLinkingURL } from 'expo-linking';
+import { useEffect, useRef, useState } from 'react';
+import { Pressable, Text } from 'react-native';
+
+import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
+import { NewPasswordForm } from '@/components/auth/new-password-form';
+import { useAuth } from '@/lib/auth/auth-provider';
+
+export default function RecoveryCallbackRoute() {
+  const callbackUrl = useLinkingURL();
+  const router = useRouter();
+  const { consumeRecoveryCallback, phase, updateRecoveryPassword } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const callbackOperation = useRef<{
+    promise: Promise<{ error?: string }>;
+    url: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!callbackUrl || phase === 'restoring' || phase === 'recovery') {
+      return;
+    }
+
+    let active = true;
+    if (callbackOperation.current?.url !== callbackUrl) {
+      callbackOperation.current = {
+        promise: consumeRecoveryCallback(callbackUrl),
+        url: callbackUrl,
+      };
+    }
+
+    void callbackOperation.current.promise.then((result) => {
+      if (active && result.error) {
+        setError(result.error);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [callbackUrl, consumeRecoveryCallback, phase]);
+
+  const updatePassword = async (password: string) => {
+    const result = await updateRecoveryPassword(password);
+    if (!result.error) {
+      router.replace({
+        params: { passwordUpdated: 'true' },
+        pathname: '/sign-in',
+      });
+    }
+    return result;
+  };
+
+  const returnToRequest = () => router.replace('/password-recovery');
+
+  if (phase === 'recovery') {
+    return (
+      <AuthScreen
+        subtitle="Choose a new password for your account."
+        title="Set new password"
+      >
+        <NewPasswordForm onSubmit={updatePassword} />
+      </AuthScreen>
+    );
+  }
+
+  return (
+    <AuthScreen title={error ? 'Recovery unavailable' : 'Opening recovery'}>
+      <Text style={authScreenStyles.link}>
+        {error ?? 'Validating your recovery link…'}
+      </Text>
+      {error ? (
+        <Pressable
+          accessibilityRole="button"
+          onPress={returnToRequest}
+          style={authScreenStyles.footerAction}
+        >
+          <Text style={authScreenStyles.footerText}>
+            Request a new recovery email
+          </Text>
+        </Pressable>
+      ) : null}
+    </AuthScreen>
+  );
+}

--- a/apps/mobile/app/auth/recovery.tsx
+++ b/apps/mobile/app/auth/recovery.tsx
@@ -1,17 +1,22 @@
-import { useRouter } from 'expo-router';
-import { useLinkingURL } from 'expo-linking';
-import { useEffect, useRef, useState } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, Text } from 'react-native';
 
 import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
 import { NewPasswordForm } from '@/components/auth/new-password-form';
 import { useAuth } from '@/lib/auth/auth-provider';
+import { RECOVERY_CALLBACK_URL } from '@/lib/auth/recovery-callback';
 
 export default function RecoveryCallbackRoute() {
-  const callbackUrl = useLinkingURL();
+  const { '#': callbackHash } = useLocalSearchParams<{ '#': string }>();
   const router = useRouter();
   const { consumeRecoveryCallback, phase, updateRecoveryPassword } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const callbackUrl = useMemo(
+    () =>
+      callbackHash ? `${RECOVERY_CALLBACK_URL}#${callbackHash}` : null,
+    [callbackHash],
+  );
   const callbackOperation = useRef<{
     promise: Promise<{ error?: string }>;
     url: string;
@@ -24,6 +29,7 @@ export default function RecoveryCallbackRoute() {
 
     let active = true;
     if (callbackOperation.current?.url !== callbackUrl) {
+      setError(null);
       callbackOperation.current = {
         promise: consumeRecoveryCallback(callbackUrl),
         url: callbackUrl,

--- a/apps/mobile/app/auth/recovery.tsx
+++ b/apps/mobile/app/auth/recovery.tsx
@@ -13,8 +13,7 @@ export default function RecoveryCallbackRoute() {
   const { consumeRecoveryCallback, phase, updateRecoveryPassword } = useAuth();
   const [error, setError] = useState<string | null>(null);
   const callbackUrl = useMemo(
-    () =>
-      callbackHash ? `${RECOVERY_CALLBACK_URL}#${callbackHash}` : null,
+    () => (callbackHash ? `${RECOVERY_CALLBACK_URL}#${callbackHash}` : null),
     [callbackHash],
   );
   const callbackOperation = useRef<{

--- a/apps/mobile/app/password-recovery.tsx
+++ b/apps/mobile/app/password-recovery.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'expo-router';
+import { Pressable, Text } from 'react-native';
+
+import { RequireSignedOut } from '@/components/auth/auth-guards';
+import { AuthScreen, authScreenStyles } from '@/components/auth/auth-screen';
+import { RecoveryRequestForm } from '@/components/auth/recovery-request-form';
+import { useAuth } from '@/lib/auth/auth-provider';
+
+function PasswordRecoveryScreen() {
+  const { requestPasswordRecovery } = useAuth();
+
+  return (
+    <AuthScreen
+      backHref="/welcome"
+      subtitle="We'll email a secure link to set a new password."
+      title="Reset your password"
+    >
+      <RecoveryRequestForm onSubmit={requestPasswordRecovery} />
+      <Link asChild href="/sign-in">
+        <Pressable
+          accessibilityRole="link"
+          style={authScreenStyles.footerAction}
+        >
+          <Text style={authScreenStyles.footerText}>
+            Remembered it?{' '}
+            <Text style={authScreenStyles.footerAccent}>Back to sign in</Text>
+          </Text>
+        </Pressable>
+      </Link>
+    </AuthScreen>
+  );
+}
+
+export default function PasswordRecoveryRoute() {
+  return (
+    <RequireSignedOut>
+      <PasswordRecoveryScreen />
+    </RequireSignedOut>
+  );
+}

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -8,7 +8,10 @@ import { useAuth } from '@/lib/auth/auth-provider';
 
 function SignInScreen() {
   const { feedback, signIn } = useAuth();
-  const { confirmed } = useLocalSearchParams<{ confirmed?: string }>();
+  const { confirmed, passwordUpdated } = useLocalSearchParams<{
+    confirmed?: string;
+    passwordUpdated?: string;
+  }>();
 
   return (
     <AuthScreen backHref="/welcome" subtitle="Welcome back." title="Sign in">
@@ -18,6 +21,11 @@ function SignInScreen() {
       {confirmed === 'true' ? (
         <Text accessibilityRole="alert" style={authScreenStyles.success}>
           Email confirmed. You can now sign in.
+        </Text>
+      ) : null}
+      {passwordUpdated === 'true' ? (
+        <Text accessibilityRole="alert" style={authScreenStyles.success}>
+          Password updated. Sign in with your new password.
         </Text>
       ) : null}
       <EmailPasswordForm
@@ -32,6 +40,17 @@ function SignInScreen() {
           <Text style={authScreenStyles.footerText}>
             Need an account?{' '}
             <Text style={authScreenStyles.footerAccent}>Create one</Text>
+          </Text>
+        </Pressable>
+      </Link>
+      <Link asChild href="/password-recovery">
+        <Pressable
+          accessibilityRole="link"
+          style={authScreenStyles.footerAction}
+        >
+          <Text style={authScreenStyles.footerText}>
+            Forgot your password?{' '}
+            <Text style={authScreenStyles.footerAccent}>Reset it</Text>
           </Text>
         </Pressable>
       </Link>

--- a/apps/mobile/components/auth/auth-guards.tsx
+++ b/apps/mobile/components/auth/auth-guards.tsx
@@ -43,6 +43,10 @@ export function RequireSignedOut({
     return <Redirect href="/home" />;
   }
 
+  if (phase === 'recovery') {
+    return <Redirect href="/auth/recovery" />;
+  }
+
   if (confirmationEmail && !allowConfirmationPending) {
     return <Redirect href="/confirmation" />;
   }

--- a/apps/mobile/components/auth/new-password-form.tsx
+++ b/apps/mobile/components/auth/new-password-form.tsx
@@ -1,0 +1,158 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { z } from 'zod';
+
+import { authScreenStyles } from '@/components/auth/auth-screen';
+
+const newPasswordSchema = z
+  .object({
+    password: z.string().min(8, 'Use at least 8 characters.'),
+    passwordConfirmation: z.string(),
+  })
+  .refine(
+    ({ password, passwordConfirmation }) => password === passwordConfirmation,
+    {
+      message: 'Passwords do not match.',
+      path: ['passwordConfirmation'],
+    },
+  );
+
+type NewPasswordValues = z.infer<typeof newPasswordSchema>;
+
+type NewPasswordFormProps = {
+  onSubmit: (password: string) => Promise<{ error?: string }>;
+};
+
+export function NewPasswordForm({ onSubmit }: NewPasswordFormProps) {
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [isPasswordVisible, setPasswordVisible] = useState(false);
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+  } = useForm<NewPasswordValues>({
+    defaultValues: { password: '', passwordConfirmation: '' },
+    resolver: zodResolver(newPasswordSchema),
+  });
+
+  const submit = async ({ password }: NewPasswordValues) => {
+    setSubmissionError(null);
+    const result = await onSubmit(password);
+    setSubmissionError(result.error ?? null);
+  };
+
+  return (
+    <View>
+      <PasswordField
+        accessibilityLabel="New password"
+        control={control}
+        error={errors.password?.message}
+        isPasswordVisible={isPasswordVisible}
+        name="password"
+        onToggleVisibility={() => setPasswordVisible((visible) => !visible)}
+        label="New password"
+      />
+      <PasswordField
+        accessibilityLabel="Confirm new password"
+        control={control}
+        error={errors.passwordConfirmation?.message}
+        isPasswordVisible={isPasswordVisible}
+        name="passwordConfirmation"
+        onToggleVisibility={() => setPasswordVisible((visible) => !visible)}
+        label="Confirm new password"
+      />
+      {submissionError ? (
+        <Text accessibilityLiveRegion="polite" style={authScreenStyles.error}>
+          {submissionError}
+        </Text>
+      ) : null}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ disabled: isSubmitting }}
+        disabled={isSubmitting}
+        onPress={handleSubmit(submit)}
+        style={[authScreenStyles.button, styles.button]}
+      >
+        <Text style={authScreenStyles.buttonText}>
+          {isSubmitting ? 'Please wait…' : 'Update password'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+type PasswordFieldProps = {
+  accessibilityLabel: string;
+  control: ReturnType<typeof useForm<NewPasswordValues>>['control'];
+  error?: string;
+  isPasswordVisible: boolean;
+  label: string;
+  name: 'password' | 'passwordConfirmation';
+  onToggleVisibility: () => void;
+};
+
+function PasswordField({
+  accessibilityLabel,
+  control,
+  error,
+  isPasswordVisible,
+  label,
+  name,
+  onToggleVisibility,
+}: PasswordFieldProps) {
+  return (
+    <>
+      <Text style={authScreenStyles.inputLabel}>{label}</Text>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field: { onBlur, onChange, value } }) => (
+          <View style={authScreenStyles.inputContainer}>
+            <TextInput
+              accessibilityLabel={accessibilityLabel}
+              autoComplete="new-password"
+              onBlur={onBlur}
+              onChangeText={onChange}
+              placeholder="Enter your new password"
+              placeholderTextColor="#7f8b9d"
+              returnKeyType={name === 'password' ? 'next' : 'done'}
+              secureTextEntry={!isPasswordVisible}
+              style={authScreenStyles.input}
+              textContentType="newPassword"
+              value={value}
+            />
+            <Pressable
+              accessibilityLabel={
+                isPasswordVisible ? 'Hide passwords' : 'Show passwords'
+              }
+              accessibilityRole="button"
+              hitSlop={8}
+              onPress={onToggleVisibility}
+              style={styles.visibilityButton}
+            >
+              <Text style={styles.visibilityButtonText}>
+                {isPasswordVisible ? 'Hide' : 'Show'}
+              </Text>
+            </Pressable>
+          </View>
+        )}
+      />
+      {error ? <Text style={styles.fieldError}>{error}</Text> : null}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: { marginTop: 22 },
+  fieldError: { color: '#ff9b9b', fontSize: 14, lineHeight: 20, marginTop: 6 },
+  visibilityButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 48,
+    minWidth: 58,
+    paddingHorizontal: 12,
+  },
+  visibilityButtonText: { color: '#aeb9c9', fontSize: 14, fontWeight: '700' },
+});

--- a/apps/mobile/components/auth/recovery-request-form.tsx
+++ b/apps/mobile/components/auth/recovery-request-form.tsx
@@ -1,0 +1,102 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { z } from 'zod';
+
+import { authScreenStyles } from '@/components/auth/auth-screen';
+
+const recoveryRequestSchema = z.object({
+  email: z.email('Enter a valid email address.'),
+});
+
+type RecoveryRequestValues = z.infer<typeof recoveryRequestSchema>;
+
+type RecoveryRequestFormProps = {
+  onSubmit: (email: string) => Promise<{ error?: string }>;
+};
+
+export function RecoveryRequestForm({ onSubmit }: RecoveryRequestFormProps) {
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+  } = useForm<RecoveryRequestValues>({
+    defaultValues: { email: '' },
+    resolver: zodResolver(recoveryRequestSchema),
+  });
+
+  const submit = async ({ email }: RecoveryRequestValues) => {
+    setSubmissionError(null);
+    const result = await onSubmit(email);
+    if (result.error) {
+      setSubmissionError(result.error);
+      return;
+    }
+
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <Text accessibilityRole="alert" style={authScreenStyles.success}>
+        If an account matches that email address, we sent a password recovery
+        link. Open it on this device.
+      </Text>
+    );
+  }
+
+  return (
+    <View>
+      <Text style={authScreenStyles.inputLabel}>Email</Text>
+      <Controller
+        control={control}
+        name="email"
+        render={({ field: { onBlur, onChange, value } }) => (
+          <View style={authScreenStyles.inputContainer}>
+            <TextInput
+              accessibilityLabel="Email"
+              autoCapitalize="none"
+              autoComplete="email"
+              keyboardType="email-address"
+              onBlur={onBlur}
+              onChangeText={onChange}
+              placeholder="you@email.com"
+              placeholderTextColor="#7f8b9d"
+              returnKeyType="done"
+              style={authScreenStyles.input}
+              textContentType="emailAddress"
+              value={value}
+            />
+          </View>
+        )}
+      />
+      {errors.email ? (
+        <Text style={styles.fieldError}>{errors.email.message}</Text>
+      ) : null}
+      {submissionError ? (
+        <Text accessibilityLiveRegion="polite" style={authScreenStyles.error}>
+          {submissionError}
+        </Text>
+      ) : null}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ disabled: isSubmitting }}
+        disabled={isSubmitting}
+        onPress={handleSubmit(submit)}
+        style={[authScreenStyles.button, styles.button]}
+      >
+        <Text style={authScreenStyles.buttonText}>
+          {isSubmitting ? 'Please wait…' : 'Send recovery link'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: { marginTop: 22 },
+  fieldError: { color: '#ff9b9b', fontSize: 14, lineHeight: 20, marginTop: 6 },
+});

--- a/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
+++ b/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
@@ -48,6 +48,7 @@ function createClient({
   signUpError = null,
   signOutError = null,
   recoveryRequestError = null,
+  recoveryRequestException = null,
   updateUserError = null,
 }: {
   initialSession?: Session | null;
@@ -64,6 +65,7 @@ function createClient({
   signUpSession?: Session | null;
   signOutError?: Error | null;
   recoveryRequestError?: Error | null;
+  recoveryRequestException?: Error | null;
   updateUserError?: Error | null;
 } = {}) {
   let listener: AuthListener | undefined;
@@ -101,10 +103,12 @@ function createClient({
         data: { session: refreshSessionError ? null : refreshSessionValue },
         error: refreshSessionError,
       }),
-      resetPasswordForEmail: jest.fn().mockResolvedValue({
-        data: {},
-        error: recoveryRequestError,
-      }),
+      resetPasswordForEmail: recoveryRequestException
+        ? jest.fn().mockRejectedValue(recoveryRequestException)
+        : jest.fn().mockResolvedValue({
+            data: {},
+            error: recoveryRequestError,
+          }),
       signInWithPassword: jest.fn().mockResolvedValue({
         data: { session: signInError ? null : session() },
         error: signInError,
@@ -132,6 +136,15 @@ function createClient({
       listener?.(event, nextSession);
     },
   };
+}
+
+function deferred<Value>() {
+  let resolve: (value: Value) => void;
+  const promise = new Promise<Value>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return { promise, resolve: resolve! };
 }
 
 function AuthProbe() {
@@ -167,6 +180,15 @@ function AuthProbe() {
       </Pressable>
       <Pressable
         onPress={() =>
+          void consumeRecoveryCallback(
+            'keylorforge://auth/recovery#access_token=second-recovery-access-token&refresh_token=second-recovery-refresh-token&type=recovery',
+          ).then((result) => setCallbackResult(result.error ?? 'success'))
+        }
+      >
+        <Text>consume second recovery</Text>
+      </Pressable>
+      <Pressable
+        onPress={() =>
           void requestPasswordRecovery('person@example.com').then((result) =>
             setCallbackResult(result.error ?? 'success'),
           )
@@ -177,7 +199,7 @@ function AuthProbe() {
       <Pressable
         onPress={() =>
           void consumeRecoveryCallback(
-            'keylorforge://auth/recovery#access_token=recovery-access-token&refresh_token=recovery-refresh-token',
+            'keylorforge://auth/recovery#access_token=recovery-access-token&refresh_token=recovery-refresh-token&type=recovery',
           ).then((result) => setCallbackResult(result.error ?? 'success'))
         }
       >
@@ -341,6 +363,29 @@ describe('AuthProvider', () => {
     expect(getByTestId('callback-result').props.children).toBe('success');
   });
 
+  it('maps a rejected recovery request to the same safe error', async () => {
+    const { client } = createClient({
+      recoveryRequestException: new Error(
+        'provider detail: person@example.com',
+      ),
+    });
+    const { getByText, getByTestId, queryByText } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    await act(async () => {
+      fireEvent.press(getByText('request recovery'));
+    });
+
+    expect(getByTestId('callback-result').props.children).toBe(
+      'We could not send the recovery email. Check your connection and try again.',
+    );
+    expect(queryByText(/provider detail/i)).toBeNull();
+  });
+
   it('keeps a recovery callback out of the signed-in shell until the password is updated', async () => {
     const { client } = createClient();
     const { getByText, getByTestId } = await render(
@@ -383,6 +428,43 @@ describe('AuthProvider', () => {
     await expectPhase(getByTestId, 'recovery');
   });
 
+  it('keeps the first recovery callback active when another callback arrives', async () => {
+    const pendingSession = deferred<{
+      data: { session: Session };
+      error: null;
+    }>();
+    const { client } = createClient();
+    const setSession = client.auth.setSession as unknown as jest.Mock;
+    setSession.mockReturnValue(pendingSession.promise);
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    fireEvent.press(getByText('consume recovery'));
+    await waitFor(() => {
+      expect(setSession).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      fireEvent.press(getByText('consume second recovery'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('callback-result').props.children).toBe(
+        'A recovery link is already being validated. Wait for it to finish or request a new recovery email.',
+      );
+    });
+    expect(getByTestId('phase').props.children).toBe('signedOut');
+    expect(setSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pendingSession.resolve({ data: { session: session() }, error: null });
+    });
+    await expectPhase(getByTestId, 'recovery');
+  });
+
   it('fails closed and removes recovery state when session setup fails', async () => {
     const { client } = createClient({
       setSessionError: new Error('provider detail: recovery-access-token'),
@@ -403,6 +485,44 @@ describe('AuthProvider', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
       '@keylorforge/auth/recovery-active',
     );
+  });
+
+  it('does not report success when local recovery sign-out fails', async () => {
+    const { client } = createClient({
+      signOutError: new Error('local storage detail'),
+    });
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    await act(async () => {
+      fireEvent.press(getByText('consume recovery'));
+    });
+    await expectPhase(getByTestId, 'recovery');
+    const cleanupCallsBeforeUpdate = jest
+      .mocked(AsyncStorage.removeItem)
+      .mock.calls.filter(
+        ([key]) => key === '@keylorforge/auth/recovery-active',
+      ).length;
+
+    await act(async () => {
+      fireEvent.press(getByText('update recovery password'));
+    });
+
+    expect(getByTestId('phase').props.children).toBe('recovery');
+    expect(getByTestId('callback-result').props.children).toBe(
+      'We could not finish this recovery safely. Request a new recovery email and try again.',
+    );
+    expect(
+      jest
+        .mocked(AsyncStorage.removeItem)
+        .mock.calls.filter(
+          ([key]) => key === '@keylorforge/auth/recovery-active',
+        ).length,
+    ).toBe(cleanupCallsBeforeUpdate);
   });
 
   it('rejects malformed recovery callbacks without mutating session state', async () => {

--- a/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
+++ b/apps/mobile/lib/auth/__tests__/auth-provider.test.tsx
@@ -47,6 +47,8 @@ function createClient({
   signUpSession = null,
   signUpError = null,
   signOutError = null,
+  recoveryRequestError = null,
+  updateUserError = null,
 }: {
   initialSession?: Session | null;
   verifiedUserEmail?: string;
@@ -61,6 +63,8 @@ function createClient({
   signUpError?: Error | null;
   signUpSession?: Session | null;
   signOutError?: Error | null;
+  recoveryRequestError?: Error | null;
+  updateUserError?: Error | null;
 } = {}) {
   let listener: AuthListener | undefined;
   const client = {
@@ -97,6 +101,10 @@ function createClient({
         data: { session: refreshSessionError ? null : refreshSessionValue },
         error: refreshSessionError,
       }),
+      resetPasswordForEmail: jest.fn().mockResolvedValue({
+        data: {},
+        error: recoveryRequestError,
+      }),
       signInWithPassword: jest.fn().mockResolvedValue({
         data: { session: signInError ? null : session() },
         error: signInError,
@@ -105,6 +113,10 @@ function createClient({
       signUp: jest.fn().mockResolvedValue({
         data: { session: signUpSession },
         error: signUpError,
+      }),
+      updateUser: jest.fn().mockResolvedValue({
+        data: { user: updateUserError ? null : session().user },
+        error: updateUserError,
       }),
       startAutoRefresh: jest.fn(),
       stopAutoRefresh: jest.fn(),
@@ -127,14 +139,17 @@ function AuthProbe() {
     clearConfirmation,
     confirmationEmail,
     consumeConfirmationCallback,
+    consumeRecoveryCallback,
     feedback,
     phase,
     invalidateSession,
     refreshSession,
+    requestPasswordRecovery,
     session: currentSession,
     signIn,
     signOut,
     signUp,
+    updateRecoveryPassword,
   } = useAuth();
   const [callbackResult, setCallbackResult] = useState('');
 
@@ -149,6 +164,42 @@ function AuthProbe() {
         onPress={() => void signIn('person@example.com', 'password123')}
       >
         <Text>sign in</Text>
+      </Pressable>
+      <Pressable
+        onPress={() =>
+          void requestPasswordRecovery('person@example.com').then((result) =>
+            setCallbackResult(result.error ?? 'success'),
+          )
+        }
+      >
+        <Text>request recovery</Text>
+      </Pressable>
+      <Pressable
+        onPress={() =>
+          void consumeRecoveryCallback(
+            'keylorforge://auth/recovery#access_token=recovery-access-token&refresh_token=recovery-refresh-token',
+          ).then((result) => setCallbackResult(result.error ?? 'success'))
+        }
+      >
+        <Text>consume recovery</Text>
+      </Pressable>
+      <Pressable
+        onPress={() =>
+          void consumeRecoveryCallback('keylorforge://auth/recovery').then(
+            (result) => setCallbackResult(result.error ?? 'success'),
+          )
+        }
+      >
+        <Text>consume malformed recovery</Text>
+      </Pressable>
+      <Pressable
+        onPress={() =>
+          void updateRecoveryPassword('new-password').then((result) =>
+            setCallbackResult(result.error ?? 'success'),
+          )
+        }
+      >
+        <Text>update recovery password</Text>
       </Pressable>
       <Pressable
         onPress={() => void signUp('person@example.com', 'password123')}
@@ -268,6 +319,110 @@ describe('AuthProvider', () => {
       password: 'password123',
       options: { emailRedirectTo: 'keylorforge://auth/confirm' },
     });
+  });
+
+  it('requests recovery through the exact stable callback without exposing account existence', async () => {
+    const { client } = createClient();
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    await act(async () => {
+      fireEvent.press(getByText('request recovery'));
+    });
+
+    expect(client.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'person@example.com',
+      { redirectTo: 'keylorforge://auth/recovery' },
+    );
+    expect(getByTestId('callback-result').props.children).toBe('success');
+  });
+
+  it('keeps a recovery callback out of the signed-in shell until the password is updated', async () => {
+    const { client } = createClient();
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    await act(async () => {
+      fireEvent.press(getByText('consume recovery'));
+    });
+
+    await expectPhase(getByTestId, 'recovery');
+    expect(client.auth.setSession).toHaveBeenCalledWith({
+      access_token: 'recovery-access-token',
+      refresh_token: 'recovery-refresh-token',
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('update recovery password'));
+    });
+
+    await expectPhase(getByTestId, 'signedOut');
+    expect(client.auth.updateUser).toHaveBeenCalledWith({
+      password: 'new-password',
+    });
+    expect(client.auth.signOut).toHaveBeenCalledWith({ scope: 'local' });
+  });
+
+  it('restores an interrupted recovery as recovery instead of signed in', async () => {
+    await AsyncStorage.setItem('@keylorforge/auth/recovery-active', 'true');
+    const { client } = createClient({ initialSession: session() });
+    const { getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'recovery');
+  });
+
+  it('fails closed and removes recovery state when session setup fails', async () => {
+    const { client } = createClient({
+      setSessionError: new Error('provider detail: recovery-access-token'),
+    });
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    await act(async () => {
+      fireEvent.press(getByText('consume recovery'));
+    });
+
+    expect(getByTestId('phase').props.children).toBe('signedOut');
+    expect(client.auth.signOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      '@keylorforge/auth/recovery-active',
+    );
+  });
+
+  it('rejects malformed recovery callbacks without mutating session state', async () => {
+    const { client } = createClient();
+    const { getByText, getByTestId } = await render(
+      <AuthProvider client={client}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await expectPhase(getByTestId, 'signedOut');
+    await act(async () => {
+      fireEvent.press(getByText('consume malformed recovery'));
+    });
+
+    expect(getByTestId('phase').props.children).toBe('signedOut');
+    expect(client.auth.setSession).not.toHaveBeenCalled();
+    expect(getByTestId('callback-result').props.children).toBe(
+      'We could not use this recovery link. Request a new recovery email and try again.',
+    );
   });
 
   it('clears the pending confirmation from memory and storage', async () => {

--- a/apps/mobile/lib/auth/__tests__/recovery-callback.test.ts
+++ b/apps/mobile/lib/auth/__tests__/recovery-callback.test.ts
@@ -11,6 +11,15 @@ describe('recovery callback parsing', () => {
         'keylorforge://auth/confirm#access_token=access-token&refresh_token=refresh-token',
       ),
     ).toEqual({ kind: 'invalid' });
+    expect(
+      parseRecoveryCallback(
+        'keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token&type=recovery',
+      ),
+    ).toEqual({
+      accessToken: 'access-token',
+      kind: 'session',
+      refreshToken: 'refresh-token',
+    });
   });
 
   it('does not surface provider callback error details', () => {
@@ -23,7 +32,22 @@ describe('recovery callback parsing', () => {
 
   it('requires both credentials from the callback fragment', () => {
     expect(
-      parseRecoveryCallback('keylorforge://auth/recovery#access_token=token'),
+      parseRecoveryCallback(
+        'keylorforge://auth/recovery#access_token=token&type=recovery',
+      ),
     ).toEqual({ kind: 'invalid' });
   });
+
+  it.each(['confirm', 'magiclink', null])(
+    'rejects a tokenized non-recovery callback type: %s',
+    (type) => {
+      const typeParameter = type ? `&type=${type}` : '';
+
+      expect(
+        parseRecoveryCallback(
+          `keylorforge://auth/recovery#access_token=access-token&refresh_token=refresh-token${typeParameter}`,
+        ),
+      ).toEqual({ kind: 'invalid' });
+    },
+  );
 });

--- a/apps/mobile/lib/auth/__tests__/recovery-callback.test.ts
+++ b/apps/mobile/lib/auth/__tests__/recovery-callback.test.ts
@@ -1,0 +1,29 @@
+import {
+  parseRecoveryCallback,
+  RECOVERY_CALLBACK_URL,
+} from '../recovery-callback';
+
+describe('recovery callback parsing', () => {
+  it('accepts only the configured KeylorForge recovery endpoint', () => {
+    expect(RECOVERY_CALLBACK_URL).toBe('keylorforge://auth/recovery');
+    expect(
+      parseRecoveryCallback(
+        'keylorforge://auth/confirm#access_token=access-token&refresh_token=refresh-token',
+      ),
+    ).toEqual({ kind: 'invalid' });
+  });
+
+  it('does not surface provider callback error details', () => {
+    expect(
+      parseRecoveryCallback(
+        'keylorforge://auth/recovery#error=access_denied&error_description=Token%20expired',
+      ),
+    ).toEqual({ kind: 'providerError' });
+  });
+
+  it('requires both credentials from the callback fragment', () => {
+    expect(
+      parseRecoveryCallback('keylorforge://auth/recovery#access_token=token'),
+    ).toEqual({ kind: 'invalid' });
+  });
+});

--- a/apps/mobile/lib/auth/__tests__/recovery-link-provider.test.tsx
+++ b/apps/mobile/lib/auth/__tests__/recovery-link-provider.test.tsx
@@ -1,0 +1,112 @@
+import { act, render } from '@testing-library/react-native';
+import * as Linking from 'expo-linking';
+import { Text } from 'react-native';
+
+import {
+  RecoveryLinkProvider,
+  useRecoveryLink,
+} from '@/lib/auth/recovery-link-provider';
+
+const mockedAddEventListener = jest.mocked(Linking.addEventListener);
+const mockedClearInitialURL = jest.mocked(Linking.clearInitialURL);
+const mockedGetLinkingURL = jest.mocked(Linking.getLinkingURL);
+let urlListener: ((event: { url: string }) => void) | undefined;
+
+jest.mock('expo-linking', () => ({
+  addEventListener: jest.fn((_type, listener) => {
+    urlListener = listener;
+    return { remove: jest.fn() };
+  }),
+  clearInitialURL: jest.fn(),
+  getLinkingURL: jest.fn(),
+}));
+
+function Probe() {
+  const { clearRecoveryLink, recoveryUrl } = useRecoveryLink();
+
+  return (
+    <>
+      <Text testID="url">{recoveryUrl ?? 'none'}</Text>
+      <Text
+        onPress={() => {
+          if (recoveryUrl) {
+            clearRecoveryLink(recoveryUrl);
+          }
+        }}
+      >
+        clear
+      </Text>
+    </>
+  );
+}
+
+describe('RecoveryLinkProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    urlListener = undefined;
+    mockedGetLinkingURL.mockReturnValue(
+      'keylorforge://auth/recovery#access_token=first&refresh_token=first-refresh&type=recovery',
+    );
+  });
+
+  it('retains the launch recovery link and a later recovery link while mounted', async () => {
+    const view = await render(
+      <RecoveryLinkProvider>
+        <Probe />
+      </RecoveryLinkProvider>,
+    );
+
+    expect(mockedAddEventListener).toHaveBeenCalledWith(
+      'url',
+      expect.any(Function),
+    );
+    expect(view.getByTestId('url').props.children).toBe(
+      'keylorforge://auth/recovery#access_token=first&refresh_token=first-refresh&type=recovery',
+    );
+
+    await act(async () => {
+      urlListener?.({
+        url: 'keylorforge://auth/recovery#access_token=second&refresh_token=second-refresh&type=recovery',
+      });
+    });
+
+    expect(view.getByTestId('url').props.children).toBe(
+      'keylorforge://auth/recovery#access_token=second&refresh_token=second-refresh&type=recovery',
+    );
+  });
+
+  it('clears a consumed launch link from memory and Expo linking cache', async () => {
+    const initialUrl =
+      'keylorforge://auth/recovery#access_token=first&refresh_token=first-refresh&type=recovery';
+    mockedGetLinkingURL.mockReturnValue(initialUrl);
+
+    const view = await render(
+      <RecoveryLinkProvider>
+        <Probe />
+      </RecoveryLinkProvider>,
+    );
+
+    await act(async () => {
+      view.getByText('clear').props.onPress();
+    });
+
+    expect(view.getByTestId('url').props.children).toBe('none');
+    expect(mockedClearInitialURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unrelated incoming links', async () => {
+    mockedGetLinkingURL.mockReturnValue(null);
+
+    const view = await render(
+      <RecoveryLinkProvider>
+        <Probe />
+      </RecoveryLinkProvider>,
+    );
+
+    await act(async () => {
+      urlListener?.({ url: 'keylorforge://profile' });
+    });
+
+    expect(view.getByTestId('url').props.children).toBe('none');
+  });
+});

--- a/apps/mobile/lib/auth/auth-provider.tsx
+++ b/apps/mobile/lib/auth/auth-provider.tsx
@@ -24,8 +24,12 @@ import {
   CONFIRMATION_CALLBACK_URL,
   parseConfirmationCallback,
 } from '@/lib/auth/confirmation-callback';
+import {
+  parseRecoveryCallback,
+  RECOVERY_CALLBACK_URL,
+} from '@/lib/auth/recovery-callback';
 
-export type AuthPhase = 'restoring' | 'signedOut' | 'signedIn';
+export type AuthPhase = 'recovery' | 'restoring' | 'signedOut' | 'signedIn';
 
 type AuthFeedback = {
   kind: 'terminal' | 'transient';
@@ -48,11 +52,14 @@ type RegistrationResult = AuthActionResult & {
 type AuthContextValue = AuthState & {
   clearConfirmation: () => Promise<void>;
   consumeConfirmationCallback: (url: string) => Promise<AuthActionResult>;
+  consumeRecoveryCallback: (url: string) => Promise<AuthActionResult>;
   invalidateSession: () => Promise<void>;
   refreshSession: () => Promise<string | null>;
+  requestPasswordRecovery: (email: string) => Promise<AuthActionResult>;
   signIn: (email: string, password: string) => Promise<AuthActionResult>;
   signOut: () => Promise<AuthActionResult>;
   signUp: (email: string, password: string) => Promise<RegistrationResult>;
+  updateRecoveryPassword: (password: string) => Promise<AuthActionResult>;
 };
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -66,6 +73,7 @@ const restoringState: AuthState = {
 
 const pendingConfirmationEmailKey =
   '@keylorforge/auth/pending-confirmation-email';
+const recoveryActiveKey = '@keylorforge/auth/recovery-active';
 
 function readableAuthError(error: AuthError | Error | null): string {
   if (!error) {
@@ -107,10 +115,24 @@ function stateForSession(session: Session | null): AuthState {
   };
 }
 
+function stateForRecovery(session: Session): AuthState {
+  return {
+    confirmationEmail: null,
+    feedback: null,
+    phase: 'recovery',
+    session,
+  };
+}
+
 function stateForRestoredSession(
   session: Session | null,
   confirmationEmail: string | null,
+  recoveryActive: boolean,
 ): AuthState {
+  if (session && recoveryActive) {
+    return stateForRecovery(session);
+  }
+
   return {
     ...stateForSession(session),
     confirmationEmail: session ? null : confirmationEmail,
@@ -163,6 +185,8 @@ export function AuthProvider({
   });
   const stateRef = useRef(authState);
   const isConsumingConfirmation = useRef(false);
+  const isConsumingRecovery = useRef(false);
+  const isUpdatingRecoveryPassword = useRef(false);
   const sessionOperationVersion = useRef(0);
 
   const updateAuthState = useCallback((nextState: AuthState) => {
@@ -171,6 +195,7 @@ export function AuthProvider({
   }, []);
 
   const setTerminalSignedOutState = useCallback(() => {
+    void AsyncStorage.removeItem(recoveryActiveKey);
     updateAuthState({
       confirmationEmail: null,
       feedback: {
@@ -197,15 +222,23 @@ export function AuthProvider({
     }
 
     const operationVersion = sessionOperationVersion.current;
-    const [{ data, error }, confirmationEmail] = await Promise.all([
-      clientResult.client.auth.getSession(),
-      AsyncStorage.getItem(pendingConfirmationEmailKey),
-    ]);
+    const [{ data, error }, confirmationEmail, recoveryActive] =
+      await Promise.all([
+        clientResult.client.auth.getSession(),
+        AsyncStorage.getItem(pendingConfirmationEmailKey),
+        AsyncStorage.getItem(recoveryActiveKey),
+      ]);
     if (operationVersion !== sessionOperationVersion.current) {
       return;
     }
     if (!error) {
-      updateAuthState(stateForRestoredSession(data.session, confirmationEmail));
+      updateAuthState(
+        stateForRestoredSession(
+          data.session,
+          confirmationEmail,
+          recoveryActive === 'true',
+        ),
+      );
       return;
     }
 
@@ -245,6 +278,7 @@ export function AuthProvider({
         }
 
         if (event === 'SIGNED_OUT') {
+          void AsyncStorage.removeItem(recoveryActiveKey);
           updateAuthState(stateForSession(null));
           return;
         }
@@ -255,6 +289,14 @@ export function AuthProvider({
         }
 
         if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+          if (
+            session &&
+            (isConsumingRecovery.current ||
+              stateRef.current.phase === 'recovery')
+          ) {
+            updateAuthState(stateForRecovery(session));
+            return;
+          }
           updateAuthState(stateForSession(session));
         }
       },
@@ -314,9 +356,32 @@ export function AuthProvider({
       }
 
       updateAuthState(stateForSession(data.session));
+      void AsyncStorage.removeItem(recoveryActiveKey);
       return {};
     },
     [clientResult.client, clientResult.error, updateAuthState],
+  );
+
+  const requestPasswordRecovery = useCallback(
+    async (email: string): Promise<AuthActionResult> => {
+      const client = clientResult.client;
+      if (!client) {
+        return { error: clientResult.error ?? 'Supabase is unavailable.' };
+      }
+
+      const { error } = await client.auth.resetPasswordForEmail(email, {
+        redirectTo: RECOVERY_CALLBACK_URL,
+      });
+      if (error) {
+        return {
+          error:
+            'We could not send the recovery email. Check your connection and try again.',
+        };
+      }
+
+      return {};
+    },
+    [clientResult.client, clientResult.error],
   );
 
   const signUp = useCallback(
@@ -430,6 +495,140 @@ export function AuthProvider({
     [clientResult.client, clientResult.error, updateAuthState],
   );
 
+  const consumeRecoveryCallback = useCallback(
+    async (url: string): Promise<AuthActionResult> => {
+      const client = clientResult.client;
+      if (!client) {
+        return { error: clientResult.error ?? 'Supabase is unavailable.' };
+      }
+
+      if (
+        isConsumingRecovery.current ||
+        stateRef.current.phase === 'recovery'
+      ) {
+        return {};
+      }
+
+      if (stateRef.current.phase === 'signedIn') {
+        return {
+          error:
+            'This recovery link cannot be used while you are signed in. Sign out and request a new link.',
+        };
+      }
+
+      const callback = parseRecoveryCallback(url);
+      if (callback.kind === 'providerError') {
+        return {
+          error:
+            'This recovery link is no longer valid. Request a new recovery email and try again.',
+        };
+      }
+
+      if (callback.kind === 'invalid') {
+        return {
+          error:
+            'We could not use this recovery link. Request a new recovery email and try again.',
+        };
+      }
+
+      isConsumingRecovery.current = true;
+      sessionOperationVersion.current += 1;
+      try {
+        await AsyncStorage.setItem(recoveryActiveKey, 'true');
+        const { data, error } = await client.auth.setSession({
+          access_token: callback.accessToken,
+          refresh_token: callback.refreshToken,
+        });
+        if (error || !data.session) {
+          try {
+            await client.auth.signOut({ scope: 'local' });
+          } finally {
+            try {
+              await AsyncStorage.removeItem(recoveryActiveKey);
+            } catch {
+              // No recovery state is exposed after a failed callback.
+            }
+          }
+          return {
+            error:
+              'This recovery link is no longer valid. Request a new recovery email and try again.',
+          };
+        }
+
+        updateAuthState(stateForRecovery(data.session));
+        return {};
+      } catch {
+        try {
+          await client.auth.signOut({ scope: 'local' });
+        } catch {
+          // Local state is still cleared below if remote cleanup fails.
+        } finally {
+          try {
+            await AsyncStorage.removeItem(recoveryActiveKey);
+          } catch {
+            // No recovery state is exposed after a failed callback.
+          }
+        }
+        return {
+          error:
+            'This recovery link is no longer valid. Request a new recovery email and try again.',
+        };
+      } finally {
+        isConsumingRecovery.current = false;
+      }
+    },
+    [clientResult.client, clientResult.error, updateAuthState],
+  );
+
+  const updateRecoveryPassword = useCallback(
+    async (password: string): Promise<AuthActionResult> => {
+      const client = clientResult.client;
+      if (!client || stateRef.current.phase !== 'recovery') {
+        return {
+          error:
+            'This recovery session is no longer valid. Request a new recovery email and try again.',
+        };
+      }
+
+      if (isUpdatingRecoveryPassword.current) {
+        return { error: 'Your password update is already in progress.' };
+      }
+
+      isUpdatingRecoveryPassword.current = true;
+      try {
+        try {
+          const { error } = await client.auth.updateUser({ password });
+          if (error) {
+            return {
+              error:
+                'We could not update your password. Request a new recovery email and try again.',
+            };
+          }
+        } catch {
+          return {
+            error:
+              'We could not update your password. Request a new recovery email and try again.',
+          };
+        }
+
+        try {
+          await client.auth.signOut({ scope: 'local' });
+        } finally {
+          try {
+            await AsyncStorage.removeItem(recoveryActiveKey);
+          } finally {
+            updateAuthState(stateForSession(null));
+          }
+        }
+
+        return {};
+      } finally {
+        isUpdatingRecoveryPassword.current = false;
+      }
+    },
+    [clientResult.client, updateAuthState],
+  );
+
   /**
    * Refreshes the Supabase session for a protected API retry.
    *
@@ -488,6 +687,7 @@ export function AuthProvider({
 
     updateAuthState(stateForSession(null));
     await AsyncStorage.removeItem(pendingConfirmationEmailKey);
+    await AsyncStorage.removeItem(recoveryActiveKey);
     return {};
   }, [clientResult.client, updateAuthState]);
 
@@ -517,21 +717,27 @@ export function AuthProvider({
       ...authState,
       clearConfirmation,
       consumeConfirmationCallback,
+      consumeRecoveryCallback,
       invalidateSession,
       refreshSession,
+      requestPasswordRecovery,
       signIn,
       signOut,
       signUp,
+      updateRecoveryPassword,
     }),
     [
       authState,
       clearConfirmation,
       consumeConfirmationCallback,
+      consumeRecoveryCallback,
       invalidateSession,
       refreshSession,
+      requestPasswordRecovery,
       signIn,
       signOut,
       signUp,
+      updateRecoveryPassword,
     ],
   );
 

--- a/apps/mobile/lib/auth/auth-provider.tsx
+++ b/apps/mobile/lib/auth/auth-provider.tsx
@@ -369,17 +369,24 @@ export function AuthProvider({
         return { error: clientResult.error ?? 'Supabase is unavailable.' };
       }
 
-      const { error } = await client.auth.resetPasswordForEmail(email, {
-        redirectTo: RECOVERY_CALLBACK_URL,
-      });
-      if (error) {
+      try {
+        const { error } = await client.auth.resetPasswordForEmail(email, {
+          redirectTo: RECOVERY_CALLBACK_URL,
+        });
+        if (!error) {
+          return {};
+        }
+
+        return {
+          error:
+            'We could not send the recovery email. Check your connection and try again.',
+        };
+      } catch {
         return {
           error:
             'We could not send the recovery email. Check your connection and try again.',
         };
       }
-
-      return {};
     },
     [clientResult.client, clientResult.error],
   );
@@ -502,10 +509,14 @@ export function AuthProvider({
         return { error: clientResult.error ?? 'Supabase is unavailable.' };
       }
 
-      if (
-        isConsumingRecovery.current ||
-        stateRef.current.phase === 'recovery'
-      ) {
+      if (isConsumingRecovery.current) {
+        return {
+          error:
+            'A recovery link is already being validated. Wait for it to finish or request a new recovery email.',
+        };
+      }
+
+      if (stateRef.current.phase === 'recovery') {
         return {};
       }
 
@@ -611,15 +622,35 @@ export function AuthProvider({
           };
         }
 
+        let signOutError: Error | null;
         try {
-          await client.auth.signOut({ scope: 'local' });
-        } finally {
-          try {
-            await AsyncStorage.removeItem(recoveryActiveKey);
-          } finally {
-            updateAuthState(stateForSession(null));
-          }
+          ({ error: signOutError } = await client.auth.signOut({
+            scope: 'local',
+          }));
+        } catch {
+          return {
+            error:
+              'We could not finish this recovery safely. Request a new recovery email and try again.',
+          };
         }
+
+        if (signOutError) {
+          return {
+            error:
+              'We could not finish this recovery safely. Request a new recovery email and try again.',
+          };
+        }
+
+        try {
+          await AsyncStorage.removeItem(recoveryActiveKey);
+        } catch {
+          return {
+            error:
+              'We could not finish this recovery safely. Request a new recovery email and try again.',
+          };
+        }
+
+        updateAuthState(stateForSession(null));
 
         return {};
       } finally {

--- a/apps/mobile/lib/auth/recovery-callback.ts
+++ b/apps/mobile/lib/auth/recovery-callback.ts
@@ -31,6 +31,10 @@ export function parseRecoveryCallback(url: string): RecoveryCallback {
       return { kind: 'providerError' };
     }
 
+    if (parameters.get('type') !== 'recovery') {
+      return { kind: 'invalid' };
+    }
+
     const accessToken = parameters.get('access_token');
     const refreshToken = parameters.get('refresh_token');
     if (!accessToken || !refreshToken) {

--- a/apps/mobile/lib/auth/recovery-callback.ts
+++ b/apps/mobile/lib/auth/recovery-callback.ts
@@ -1,0 +1,44 @@
+import 'react-native-url-polyfill/auto';
+
+export const RECOVERY_CALLBACK_URL = 'keylorforge://auth/recovery';
+
+export type RecoveryCallback =
+  | { kind: 'providerError' }
+  | {
+      accessToken: string;
+      kind: 'session';
+      refreshToken: string;
+    }
+  | { kind: 'invalid' };
+
+/**
+ * Reads only the implicit-flow session fields accepted at the recovery endpoint.
+ * Callers must never render or log the callback URL or either credential.
+ */
+export function parseRecoveryCallback(url: string): RecoveryCallback {
+  try {
+    const callback = new URL(url);
+    if (
+      callback.protocol !== 'keylorforge:' ||
+      callback.hostname !== 'auth' ||
+      callback.pathname !== '/recovery'
+    ) {
+      return { kind: 'invalid' };
+    }
+
+    const parameters = new URLSearchParams(callback.hash.slice(1));
+    if (parameters.has('error') || parameters.has('error_code')) {
+      return { kind: 'providerError' };
+    }
+
+    const accessToken = parameters.get('access_token');
+    const refreshToken = parameters.get('refresh_token');
+    if (!accessToken || !refreshToken) {
+      return { kind: 'invalid' };
+    }
+
+    return { accessToken, kind: 'session', refreshToken };
+  } catch {
+    return { kind: 'invalid' };
+  }
+}

--- a/apps/mobile/lib/auth/recovery-link-provider.tsx
+++ b/apps/mobile/lib/auth/recovery-link-provider.tsx
@@ -1,0 +1,90 @@
+import * as Linking from 'expo-linking';
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { RECOVERY_CALLBACK_URL } from '@/lib/auth/recovery-callback';
+
+type RecoveryLinkContextValue = {
+  clearRecoveryLink: (url: string) => void;
+  recoveryUrl: string | null;
+};
+
+const RecoveryLinkContext = createContext<RecoveryLinkContextValue | undefined>(
+  undefined,
+);
+
+function isRecoveryEndpoint(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const expected = new URL(RECOVERY_CALLBACK_URL);
+
+    return (
+      parsed.protocol === expected.protocol &&
+      parsed.hostname === expected.hostname &&
+      parsed.pathname === expected.pathname
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Keeps the latest recovery deep link above the router so route transitions
+ * cannot miss a URL event while /auth/recovery is mounting.
+ *
+ * Recovery credentials live only in memory and are never logged or persisted.
+ */
+export function RecoveryLinkProvider({ children }: PropsWithChildren) {
+  const [recoveryUrl, setRecoveryUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const capture = (url: string | null) => {
+      if (url && isRecoveryEndpoint(url)) {
+        setRecoveryUrl(url);
+      }
+    };
+
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      capture(url);
+    });
+
+    capture(Linking.getLinkingURL());
+
+    return () => subscription.remove();
+  }, []);
+
+  const clearRecoveryLink = useCallback((url: string) => {
+    setRecoveryUrl((current) => (current === url ? null : current));
+
+    if (Linking.getLinkingURL() === url) {
+      Linking.clearInitialURL();
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ clearRecoveryLink, recoveryUrl }),
+    [clearRecoveryLink, recoveryUrl],
+  );
+
+  return (
+    <RecoveryLinkContext.Provider value={value}>
+      {children}
+    </RecoveryLinkContext.Provider>
+  );
+}
+
+export function useRecoveryLink(): RecoveryLinkContextValue {
+  const value = useContext(RecoveryLinkContext);
+  if (!value) {
+    throw new Error('useRecoveryLink must be rendered within RecoveryLinkProvider.');
+  }
+
+  return value;
+}

--- a/apps/mobile/lib/auth/recovery-link-provider.tsx
+++ b/apps/mobile/lib/auth/recovery-link-provider.tsx
@@ -83,7 +83,9 @@ export function RecoveryLinkProvider({ children }: PropsWithChildren) {
 export function useRecoveryLink(): RecoveryLinkContextValue {
   const value = useContext(RecoveryLinkContext);
   if (!value) {
-    throw new Error('useRecoveryLink must be rendered within RecoveryLinkProvider.');
+    throw new Error(
+      'useRecoveryLink must be rendered within RecoveryLinkProvider.',
+    );
   }
 
   return value;


### PR DESCRIPTION
## Summary
Implement the IDN-005 mobile password-recovery flow and secure recovery deep-link handling.

## Changes
- Add a uniform password-recovery request and an accessible new-password form.
- Consume only exact `keylorforge://auth/recovery` callbacks carrying `type=recovery`; reject malformed, missing-type, and wrong-flow callbacks before session installation.
- Isolate recovery navigation, make callback handling fail closed and single-flight, and harden reset/sign-out errors.
- Add direct UI/route coverage for recovery request, recovery callback/new-password flow, and the Sign in recovery entry point.
- Stabilize React 19 / RNTL async UI interactions using the repository's existing `await act(...)` testing pattern.
- Document the required Android development-build physical acceptance run.

## Validation
- Mobile CI: success — formatting, lint, TypeScript and Jest all passed on head `3f7701d2`.
- Backend CI: success.
- Database Migration CI: success.
- KeylorForge residual check: success.
- Physical-device recovery acceptance has not been run yet.

## Risks and assumptions
- Supabase must allow exactly `keylorforge://auth/recovery` without wildcards and deliver the expected recovery callback type.
- Android custom-scheme interception remains a known residual risk; App Links are outside this issue's scope.

## Gate
Keep this PR in draft until the Product Owner completes the physical Android recovery journey successfully.

## Rollback
Revert the commits in this PR to remove the mobile recovery flow.